### PR TITLE
single query to display both progress and plan view

### DIFF
--- a/dashboard/static/js/assign-progress.js
+++ b/dashboard/static/js/assign-progress.js
@@ -1,219 +1,200 @@
-var makeGraph = function () {
+jQuery(document).ready(function ($) {
     d3.selectAll("#chart > *").remove();
-    $.getJSON("/api/v1/courses/"+dashboard.course_id+"/assignment_progress", function (initResult) {
-        data = initResult;
-        if(_.isEmpty(data)){
-            var gradeInfo = d3.select("#chart").append("div")
-                .attr("class", "alert alert-info")
-                .attr("role","alert")
-                .style("font-size", "20px")
-                .style("font-weight", "bold")
-                .html('No data for the view')
-            return
-        }
+    var ctrlName = 'mainController'
+    var sel = 'div[ng-controller="' + ctrlName + '"]';
+    var data = angular.element(sel).scope().progress
+    var tooltip = d3.select("body").append("div").attr("class", "tooltip").style("opacity", 0);
 
-        var tooltip = d3.select("body").append("div").attr("class", "tooltip").style("opacity", 0);
+    var width = 1500,
+        height = 100;
 
-        var width = 1500,
-            height = 100;
+    var margin = {
+        top: 20,
+        right: 30,
+        bottom: 30,
+        left: 30
+    };
 
-        var margin = {
-            top: 20,
-            right: 30,
-            bottom: 30,
-            left: 30
-        };
+    var svg = d3.select("#chart").append("svg")
+        .attr('width', '100%')
+        .attr('height', '100%')
+        .attr('viewBox', '0 0 ' + width + ' ' + height)
+        .attr("preserveAspectRatio", "xMinYMin")
+        .append('g');
 
-        var svg = d3.select("#chart").append("svg")
-            .attr('width', '100%')
-            .attr('height', '100%')
-            .attr('viewBox', '0 0 ' + width + ' ' + height)
-            .attr("preserveAspectRatio", "xMinYMin")
-            .append('g');
-
-        width = width - margin.left - margin.right,
+    width = width - margin.left - margin.right,
         height = height - margin.top - margin.bottom;
 
-        svg.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+    svg.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-        // Create x and y scale.
+    // Create x and y scale.
 
-        var xScale = d3.scaleLinear()
-            .range([0, width]);
+    var xScale = d3.scaleLinear()
+        .range([0, width]);
 
-        var yScale = d3.scaleBand()
-            .range([0, height]);
+    var yScale = d3.scaleBand()
+        .range([0, height]);
 
-        xScale.domain([0, 100]);
+    xScale.domain([0, 100]);
 
-        var x_axis = svg.append('g')
-            .attr('class', 'axis')
-            .attr('transform', 'translate(' + 0 + ',' + height + ')')
-            .attr('stroke-width','2')
-            .call(d3.axisBottom(xScale)
-                .tickFormat(function(d) {
-                    return d+"%"
-                })
-                .ticks(20, 's'))
-
-
-        perc_so_far = 0;
-        dperc_so_far = 0;
-        //
-        var bar = svg.selectAll(null)
-            .data(data)
-            .enter().append("g")
-
-        bar.append("rect")
-            .attr("width", function(d) {
-                var prev_perc = perc_so_far;
-                var this_perc = d.percent_gotten;
-                perc_so_far = perc_so_far + this_perc;
-                return xScale(perc_so_far) - xScale(prev_perc)
+    var x_axis = svg.append('g')
+        .attr('class', 'axis')
+        .attr('transform', 'translate(' + 0 + ',' + height + ')')
+        .attr('stroke-width', '2')
+        .call(d3.axisBottom(xScale)
+            .tickFormat(function (d) {
+                return d + "%"
             })
-            .attr("x", function(d) {
-                var dprev_perc = dperc_so_far;
-                var dthis_perc = d.percent_gotten;
-                dperc_so_far = dperc_so_far + dthis_perc;
-                return (xScale(dprev_perc)) ;
-            })
-            .attr("height",  yScale.bandwidth())
-            .on("mouseover", function(d) {
-                d3.select(this).attr("class", function(d){
-                    //programming hack to reduce the flickering effect
-                    return (d.graded===true)? "progress-hover-graded":"progress-hover-notgraded";
-                });
-                tooltip.transition()
-                    .duration(200)
-                    .style("opacity", 1);
-                var coordinates = d3.mouse(this);
-                var tooltipVal="Assignment: <b>" + (d.name) + "</b><br>" +
-                    "Due at: <b>" + (d.due_dates) + "</b><br>" +
-                    "Your grade is: <b>" + ((!d.score) ? "Not available" : (d.score)) + "</b><br>" +
-                    "Total Points Possible: <b>" + (d.points_possible) + "</b><br>" +
-                    "Percentage worth in final grade: <b>" + (d.towards_final_grade) + "%</b><br>" +
-                    ((d.drop_lowest != 0) ? "The lowest <b>" + d.drop_lowest + "</b> scores will dropped from this assignment group" : '') +
-                    ((d.drop_highest != 0) ? "The highest <b>" + d.drop_highest + "</b> scores will dropped from this assignment group" : '');
-                if ((width - coordinates[0]) < 50) {
-                    tooltip.html(tooltipVal)
-                        .style("left", (d3.event.pageX)-(d3.event.pageY*2) + "px")
-                        .style("top", (d3.event.pageY)-150 + "px");
-                } else {
-                    tooltip.html(tooltipVal)
-                        .style("left", (d3.event.pageX)+ "px")
-                        .style("top", (d3.event.pageY) + "px");
-                }
-            })
-            .on("mouseout", function(d) {
-                tooltip.transition()
-                    .duration(500)
-                    .style("opacity", 0);
-                d3.select(this).attr("class", function(d){
-                    return (d.graded===true)? "progress-graded":"progress-nongraded";
-                });
-            })
-            .attr("class",function(d){
-                return (d.graded===true)? "progress-graded":"progress-nongraded";
+            .ticks(20, 's'))
+
+
+    perc_so_far = 0;
+    dperc_so_far = 0;
+    //
+    var bar = svg.selectAll(null)
+        .data(data)
+        .enter().append("g")
+
+    bar.append("rect")
+        .attr("width", function (d) {
+            var prev_perc = perc_so_far;
+            var this_perc = d.percent_gotten;
+            perc_so_far = perc_so_far + this_perc;
+            return xScale(perc_so_far) - xScale(prev_perc)
+        })
+        .attr("x", function (d) {
+            var dprev_perc = dperc_so_far;
+            var dthis_perc = d.percent_gotten;
+            dperc_so_far = dperc_so_far + dthis_perc;
+            return (xScale(dprev_perc));
+        })
+        .attr("height", yScale.bandwidth())
+        .on("mouseover", function (d) {
+            d3.select(this).attr("class", function (d) {
+                //programming hack to reduce the flickering effect
+                return (d.graded === true) ? "progress-hover-graded" : "progress-hover-notgraded";
             });
-
-        perc_so_far = 0;
-        let gradeIndicator = [...new Set(data.map(item => item.graded))];
-        var currentWeekXValue=''
-        var maxPossibleWeekXValue=''
-        bar.append("text")
-            .attr("x", function(d,i) {
-                var dprev_perc = perc_so_far;
-                var dthis_perc = d.percent_gotten;
-                perc_so_far = perc_so_far + dthis_perc;
-                xCoordinate=xScale(dprev_perc)
-                if(gradeIndicator.length==2) {
-                    if (d.graded) {
-                        currentWeekXValue = xScale(perc_so_far);
-                    }
-                    if (data.length == i + 1) {
-                        maxPossibleWeekXValue = xScale(perc_so_far);
-                    }
-                }
-                if(gradeIndicator.length==1 && data.length == i + 1 ){
-                    if(gradeIndicator[0]){
-                        currentWeekXValue=xScale(perc_so_far);
-                    }
-                    if(!gradeIndicator[0]){
-                        maxPossibleWeekXValue = xScale(perc_so_far);
-                    }
-                }
-                return (xCoordinate)
-            })
-            .attr("dy", "2.4em")
-            .attr("dx",".6em")
-            .text(function(d,i) {
-                if (parseFloat(d.percent_gotten) < 2.0) {
-                    return "";
-                }
-                if (d.name.length > 5) {
-                    return d.name.substring(0, 5) + '...';
-                } else {
-                    return d.name;
-                }
-            });
-            if(currentWeekXValue.length!=0) {
-                if(currentWeekXValue<6){
-                  dxValue = "1.6em";
-                }else {
-                    dxValue=".4em";
-                }
-                var currentLine = svg.append("g")
-                currentLine.append('line')
-                    .attr('x1', currentWeekXValue)
-                    .attr('y1', 0-margin.top)
-                    .attr('x2', currentWeekXValue)
-                    .attr('y2', height)
-                    .attr('stroke', 'darkorange')
-                    .attr('stroke-width', '1')
-                currentLine.append('text')
-                    .attr('text-anchor', 'middle')
-                    .attr("x", currentWeekXValue - 30)
-                    .attr("dx", dxValue)
-                    .attr("y", -9)
-                    .attr("fill","darkorange")
-                    .attr("font-size","19px")
-                    .attr("font-weight","bold")
-                    // .attr("dy", ".9em")
-                    .text('Current')
+            tooltip.transition()
+                .duration(200)
+                .style("opacity", 1);
+            var coordinates = d3.mouse(this);
+            var tooltipVal = "Assignment: <b>" + (d.name) + "</b><br>" +
+                "Due at: <b>" + (d.due_dates) + "</b><br>" +
+                "Your grade is: <b>" + ((!d.score) ? "Not available" : (d.score)) + "</b><br>" +
+                "Total Points Possible: <b>" + (d.points_possible) + "</b><br>" +
+                "Percentage worth in final grade: <b>" + (d.towards_final_grade) + "%</b><br>" +
+                ((d.drop_lowest != 0) ? "The lowest <b>" + d.drop_lowest + "</b> scores will dropped from this assignment group" : '') +
+                ((d.drop_highest != 0) ? "The highest <b>" + d.drop_highest + "</b> scores will dropped from this assignment group" : '');
+            if ((width - coordinates[0]) < 50) {
+                tooltip.html(tooltipVal)
+                    .style("left", (d3.event.pageX) - (d3.event.pageY * 2) + "px")
+                    .style("top", (d3.event.pageY) - 150 + "px");
+            } else {
+                tooltip.html(tooltipVal)
+                    .style("left", (d3.event.pageX) + "px")
+                    .style("top", (d3.event.pageY) + "px");
             }
-        if(maxPossibleWeekXValue.length!=0) {
-            var maxLine = svg.append("g")
-            maxLine.append('line')
-                .attr('x1', maxPossibleWeekXValue)
-                .attr('y1', 0-margin.top)
-                .attr('x2', maxPossibleWeekXValue)
-                .attr('y2', height)
-                .attr('stroke', 'green')
-                .attr('stroke-width', '1')
-            maxLine.append('text')
-                .attr('text-anchor', 'middle')
-                .attr("x", maxPossibleWeekXValue - 50)
-                .attr("dx", '.5em')
-                .attr("y", -9)
-                // .attr("dy", ".9em")
-                .attr('fill', 'green')
-                .attr("font-weight","bold")
-                .text('Max Possible')
+        })
+        .on("mouseout", function (d) {
+            tooltip.transition()
+                .duration(500)
+                .style("opacity", 0);
+            d3.select(this).attr("class", function (d) {
+                return (d.graded === true) ? "progress-graded" : "progress-nongraded";
+            });
+        })
+        .attr("class", function (d) {
+            return (d.graded === true) ? "progress-graded" : "progress-nongraded";
+        });
+
+    perc_so_far = 0;
+    let gradeIndicator = [...new Set(data.map(item => item.graded))];
+    var currentWeekXValue = ''
+    var maxPossibleWeekXValue = ''
+    bar.append("text")
+        .attr("x", function (d, i) {
+            var dprev_perc = perc_so_far;
+            var dthis_perc = d.percent_gotten;
+            perc_so_far = perc_so_far + dthis_perc;
+            xCoordinate = xScale(dprev_perc)
+            if (gradeIndicator.length == 2) {
+                if (d.graded) {
+                    currentWeekXValue = xScale(perc_so_far);
+                }
+                if (data.length == i + 1) {
+                    maxPossibleWeekXValue = xScale(perc_so_far);
+                }
+            }
+            if (gradeIndicator.length == 1 && data.length == i + 1) {
+                if (gradeIndicator[0]) {
+                    currentWeekXValue = xScale(perc_so_far);
+                }
+                if (!gradeIndicator[0]) {
+                    maxPossibleWeekXValue = xScale(perc_so_far);
+                }
+            }
+            return (xCoordinate)
+        })
+        .attr("dy", "2.4em")
+        .attr("dx", ".6em")
+        .text(function (d, i) {
+            if (parseFloat(d.percent_gotten) < 2.0) {
+                return "";
+            }
+            if (d.name.length > 5) {
+                return d.name.substring(0, 5) + '...';
+            } else {
+                return d.name;
+            }
+        });
+    if (currentWeekXValue.length != 0) {
+        if (currentWeekXValue < 6) {
+            dxValue = "1.6em";
+        } else {
+            dxValue = ".4em";
         }
+        var currentLine = svg.append("g")
+        currentLine.append('line')
+            .attr('x1', currentWeekXValue)
+            .attr('y1', 0 - margin.top)
+            .attr('x2', currentWeekXValue)
+            .attr('y2', height)
+            .attr('stroke', 'darkorange')
+            .attr('stroke-width', '1')
+        currentLine.append('text')
+            .attr('text-anchor', 'middle')
+            .attr("x", currentWeekXValue - 30)
+            .attr("dx", dxValue)
+            .attr("y", -9)
+            .attr("fill", "darkorange")
+            .attr("font-size", "19px")
+            .attr("font-weight", "bold")
+            // .attr("dy", ".9em")
+            .text('Current')
+    }
+    if (maxPossibleWeekXValue.length != 0) {
+        var maxLine = svg.append("g")
+        maxLine.append('line')
+            .attr('x1', maxPossibleWeekXValue)
+            .attr('y1', 0 - margin.top)
+            .attr('x2', maxPossibleWeekXValue)
+            .attr('y2', height)
+            .attr('stroke', 'green')
+            .attr('stroke-width', '1')
+        maxLine.append('text')
+            .attr('text-anchor', 'middle')
+            .attr("x", maxPossibleWeekXValue - 50)
+            .attr("dx", '.5em')
+            .attr("y", -9)
+            // .attr("dy", ".9em")
+            .attr('fill', 'green')
+            .attr("font-weight", "bold")
+            .text('Max Possible')
+    }
 
-        // d3.select(window).on('resize', resize);
-        // function resize () {
-        //     var width = parseInt(d3.select("#chart").style("width"));
-        // }
+    // d3.select(window).on('resize', resize);
+    // function resize () {
+    //     var width = parseInt(d3.select("#chart").style("width"));
+    // }
 
-    }).fail(function(jqXHR, textStatus, errorThrown) {
-        var gradeInfo = d3.select(".error").append("div")
-            .attr("class", "alert alert-danger")
-            .attr("role","alert")
-            .style("font-size", "20px")
-            .style("font-weight", "bold")
-            .html('Some error has occurred please try later or refresh the browser')
-    });
-};
-
-makeGraph();
+});

--- a/dashboard/static/js/controllers.js
+++ b/dashboard/static/js/controllers.js
@@ -11,8 +11,8 @@ visApp.controller('mainController', ['$scope', 'Get','$location', '$anchorScroll
             $scope.plan = data.data.plan
             $scope.progress = data.data.progress
             // call the js file onload only
-            if (call == 1) {
-                $.getScript("/static/js/assign-progress.js")
+            if (call == 'assign-progress.js') {
+                $.getScript("/static/js/"+call)
             }
             scrollId = 1
             $scope.plan.find(function (e) {
@@ -31,7 +31,7 @@ visApp.controller('mainController', ['$scope', 'Get','$location', '$anchorScroll
     $scope.percent = [{ "value": 0, "text": "0% (all)" }, { "value": 2, "text": "2%" },{ "value": 5, "text": "5%" },
         { "value": 10, "text": "10%" },{ "value": 20, "text": "20%" },{ "value": 50, "text": "50%" },{ "value": 75, "text": "75%" }];
     $scope.percent_filter=$scope.percent[0].value;
-    dataCall(1);
+    dataCall('assign-progress.js');
 
     $scope.updatePercentFilter = function() {
         dataCall();

--- a/dashboard/static/js/controllers.js
+++ b/dashboard/static/js/controllers.js
@@ -1,14 +1,24 @@
 visApp.controller('mainController', ['$scope', 'Get','$location', '$anchorScroll', function($scope, Get,$location,$anchorScroll) {
 
-   function dataCall(){
-        var dataFile = '/api/v1/courses/'+dashboard.course_id+'/assignment_view?percent='+$scope.percent_filter;
+   function dataCall(call){
+        var dataFile = '/api/v1/courses/'+dashboard.course_id+'/assignments?percent='+$scope.percent_filter;
         Get.getData(dataFile).then(function(data) {
-            $scope.data = data.data
-            scrollId=1
-            $scope.data.find(function (e) {
-                current_week_indicator=e.due_date_items[0].assignment_items[0].current_week
-                if(current_week_indicator){
-                    return scrollId=e.id;
+            if (_.isEmpty(data.data)) {
+                $scope.plan = []
+                $scope.progress = []
+                return;
+            }
+            $scope.plan = data.data.plan
+            $scope.progress = data.data.progress
+            // call the js file onload only
+            if (call == 1) {
+                $.getScript("/static/js/assign-progress.js")
+            }
+            scrollId = 1
+            $scope.plan.find(function (e) {
+                current_week_indicator = e.due_date_items[0].assignment_items[0].current_week
+                if (current_week_indicator) {
+                    return scrollId = e.id;
                 }
 
             })
@@ -17,12 +27,11 @@ visApp.controller('mainController', ['$scope', 'Get','$location', '$anchorScroll
         });
     }
 
-    $scope.data=[]
     $scope.percentFilterEnabled=true;
     $scope.percent = [{ "value": 0, "text": "0% (all)" }, { "value": 2, "text": "2%" },{ "value": 5, "text": "5%" },
         { "value": 10, "text": "10%" },{ "value": 20, "text": "20%" },{ "value": 50, "text": "50%" },{ "value": 75, "text": "75%" }];
     $scope.percent_filter=$scope.percent[0].value;
-    dataCall();
+    dataCall(1);
 
     $scope.updatePercentFilter = function() {
         dataCall();

--- a/dashboard/templates/assignments.html
+++ b/dashboard/templates/assignments.html
@@ -7,14 +7,18 @@
 
 {% block content %}
 {% if course_view_option.show_assignment_planning %}
+<div ng-controller="mainController" ng-app="visApp">
 <div class="container-fluid">
     <h5 style="padding-left: 10px">Progress toward Final Grade</h5>
     <div id="chart"></div>
+    <div ng-show="progress.length == 0" class="alert alert-info">
+        There's no data
+    </div>
 </div>
 <br><br>
 <div class="container-fluid">
 <div class="row">
-<div style="padding-left: 40px"  class="col-lg" ng-controller="mainController" ng-app="visApp">
+<div style="padding-left: 40px"  class="col-lg">
     <div class="row">
         <div class="column">
             <h5>Assignments Due By Date</h5>
@@ -42,7 +46,7 @@
     {% verbatim %}
     <div class="table-style">
         <table class="table table_container">
-            <tr ng-if="data.length!=0" ng-repeat="week in data" id="{{week.id}}">
+            <tr ng-if="plan.length!=0" ng-repeat="week in plan" id="{{week.id}}">
                 <td ng-if="!week.due_date_items[0].assignment_items[0].current_week" >Week {{week.week}}</td>
                 <td ng-if="week.due_date_items[0].assignment_items[0].current_week" class="current-week-indicator">Week {{week.week}}</td>
                 <td class="table_container table_container1">
@@ -86,7 +90,7 @@
 
             </tr>
 
-            <td ng-show="data.length == 0">
+            <td ng-show="plan.length == 0">
                 There's no data for selection
             </td>
 
@@ -98,6 +102,7 @@
 </div>
 </div>
 </div>
+</div>
 {% else %}
     Assignment Planning view is hidden for this course.
 {% endif %}
@@ -105,7 +110,6 @@
 
 {% block js %}
 <script src="{% static 'd3-v4/build/d3.min.js' %}"></script>
-<script src="/static/js/assign-progress.js"></script>
 <script src="{% static 'js/app.js' %}"></script>
 <script src="{% static 'js/controllers.js' %}"></script>
 <script src="{% static 'js/factories.js' %}"></script>

--- a/dashboard/templates/assignments.html
+++ b/dashboard/templates/assignments.html
@@ -12,7 +12,7 @@
     <h5 style="padding-left: 10px">Progress toward Final Grade</h5>
     <div id="chart"></div>
     <div ng-show="progress.length == 0" class="alert alert-info">
-        There's no data
+        There's no assignment progress data
     </div>
 </div>
 <br><br>
@@ -91,7 +91,7 @@
             </tr>
 
             <td ng-show="plan.length == 0">
-                There's no data for selection
+                There's no assignment planning data for selection
             </td>
 
         </table>

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -48,8 +48,7 @@ urlpatterns = [
     # get file access patterns
     url(r'^api/v1/courses/(?P<course_id>[0-9]+)/grade_distribution', login_required(views.grade_distribution), name='grade_distribution'),
     url(r'^api/v1/courses/(?P<course_id>[0-9]+)/file_access_within_week', login_required(views.file_access_within_week), name='file_access_within_week'),
-    url(r'^api/v1/courses/(?P<course_id>[0-9]+)/assignment_view', login_required(views.assignment_view), name='assignment_view'),
-    url(r'^api/v1/courses/(?P<course_id>[0-9]+)/assignment_progress', login_required(views.assignment_progress), name='assignment_progress'),
+    url(r'^api/v1/courses/(?P<course_id>[0-9]+)/assignments', login_required(views.assignments), name='assignments'),
     url(r'^api/v1/get_current_week_number', login_required(views.get_current_week_number), name='get_current_week_number'),
 
     url(r'^su/', include('django_su.urls')),

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -235,37 +235,8 @@ def grade_distribution(request, course_id=0):
     return HttpResponse(df.to_json(orient='records'))
 
 
-def assignment_progress(request, course_id=0):
-    logger.info(assignment_progress.__name__)
-
-    current_user = request.user.get_username()
-    df_default_display_settings()
-
-    assignments_in_course = get_course_assignments(course_id)
-    if assignments_in_course.empty:
-        return HttpResponse(json.dumps({}), content_type='application/json')
-    assignment_submissions = get_user_assignment_submission(current_user, assignments_in_course,course_id)
-
-    df = pd.merge(assignments_in_course, assignment_submissions, on='assignment_id', how='left')
-    if df.empty:
-        logger.info('There are no assignment data in the course %s for user %s '%(course_id, current_user))
-        return HttpResponse(json.dumps([]), content_type='application/json')
-
-    df['graded']= df['graded'].fillna(False)
-    df.sort_values(by='due_date', inplace=True)
-    df.drop(columns=['assignment_id', 'due_date'], inplace=True)
-    df.drop_duplicates(keep='first', inplace=True)
-    df = df[df['towards_final_grade']>0.0]
-    df[['score']] = df[['score']].astype(float)
-    df['percent_gotten']=df.apply(user_percent,axis=1)
-    df.sort_values(by=['graded','due_date_mod'], ascending=[False,True],inplace = True)
-    df.reset_index(inplace=True)
-    df.drop(columns=['index'],inplace=True)
-    logger.debug('The Dataframe for the assignment progress %s ' %df)
-    return HttpResponse(df.to_json(orient='records'))
-
-def assignment_view(request, course_id=0):
-    logger.info(assignment_view.__name__)
+def assignments(request, course_id=0):
+    logger.info(assignments.__name__)
 
     current_user = request.user.get_username()
     df_default_display_settings()
@@ -296,6 +267,20 @@ def assignment_view(request, course_id=0):
     df.sort_values(by='due_date', inplace=True)
     df.drop(columns=['assignment_id', 'due_date'], inplace=True)
     df.drop_duplicates(keep='first', inplace=True)
+
+    df3 = df[df['towards_final_grade']>0.0]
+    df3[['score']] = df3[['score']].astype(float)
+    df3['percent_gotten']=df3.apply(user_percent,axis=1)
+    df3['graded']= df3['graded'].fillna(False)
+    df3[['score']] = df3[['score']].astype(float)
+    df3['percent_gotten']=df3.apply(user_percent,axis=1)
+    df3.sort_values(by=['graded','due_date_mod'], ascending=[False,True],inplace = True)
+    df3.reset_index(inplace=True)
+    df3.drop(columns=['index'],inplace=True)
+
+    assignment_data={}
+    assignment_data['progress']=json.loads(df3.to_json(orient='records'))
+
 
     # Group the data according the assignment prep view
     df2 = df[df['towards_final_grade'] >= percent_selection]
@@ -331,7 +316,9 @@ def assignment_view(request, course_id=0):
                 assignment_due_date_grp['assignment_items'] = item['assign']
                 dd_items.append(assignment_due_date_grp)
         full.append(data)
-    return HttpResponse(json.dumps(full), content_type='application/json')
+    assignment_data['plan']=json.loads(json.dumps(full))
+    return HttpResponse(json.dumps(assignment_data), content_type='application/json')
+
 
 def get_course_assignments(course_id):
     sql="select assignment_id,name,due_date,points_possible,group_points,weight,drop_lowest,drop_highest from " \


### PR DESCRIPTION
This PR is addressing the assignment view backed call processing. instead of 2 separate calls to present assignment progress and plan view single DB query is doing it all. Now the Controller is handling both the data for the views. The Progress JS is loaded after assignment data call so that progress data is made available  

The `assign_progress.js` has a lot of white space changes in order to ignore the white space changes use the GitHub UI as show here
![screen shot 2018-11-19 at 8 09 22 am](https://user-images.githubusercontent.com/8579775/48709170-b6f57800-ebd2-11e8-974b-b8571354db44.png)
