### PR TITLE
Improve docker dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+.data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ COPY start.sh /start.sh
 
 # EXPOSE port 5000 to allow communication to/from server
 EXPOSE 5000
-WORKDIR /dashboard/
-COPY . /dashboard/
+WORKDIR /code/
+COPY . /code/
 
 COPY manage.py /manage.py
 
@@ -31,7 +31,7 @@ COPY data/* /data/
 RUN yarn global add wait-port@"~0.2.2" && \
     yarn install && \ 
 # This is needed to clean up the examples files as these cause collectstatic to fail (and take up extra space)
-    find /usr/lib/node_modules /dashboard/node_modules -type d -name "examples" -print0 | xargs -0 rm -rf && \
+    find /usr/lib/node_modules /code/node_modules -type d -name "examples" -print0 | xargs -0 rm -rf && \
 # This DJANGO_SECRET_KEY is set here just so collectstatic runs with an empty key. It can be set to anything
     echo yes | DJANGO_SECRET_KEY="collectstatic" python manage.py collectstatic --verbosity 0
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This will remove everything! (images, containers, volumes)
     then install a text editor like vim
     `apt-get -y install vim`
 
-Then you can edit your files! (Probably in /dashboard/dashboard)
+Then you can edit your files! (Probably in /code/dashboard)
 
 2. Restart the gunicorn to read the configuration. This is useful to avoid a redeploy.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     ports:
       - "5306:3306"
     volumes:
+      - ./.data/mysql:/var/lib/mysql
       - ./mysql:/docker-entrypoint-initdb.d/:ro
     container_name: student_dashboard_mysql
   web:
@@ -29,6 +30,8 @@ services:
     command: bash -c "./start.sh"
     volumes:
       - .:/code
+      # use the container's node_modules folder (don't override)
+      - /code/node_modules/
     ports:
       - "5001:5000"
       - "3000:3000"
@@ -37,4 +40,6 @@ services:
       - mysql
     env_file:
       - .env
+    environment:
+      - GUNICORN_RELOAD=True
     container_name: student_dashboard


### PR DESCRIPTION
- add gunicorn reload option for dev
- load local code changes into image (compose-file used `/code` but dockerfile was using `/dashbaord`. switch dockerfile to use `/code`)
- persist mysql container data

Related #121