### PR TITLE
Allows control over view options globally

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -146,3 +146,6 @@ PTVSD_WAIT_FOR_ATTACH=
 
 # How long to cache some URL's on the client (Defualt 3600 seconds)
 CLIENT_CACHE_TIME =
+
+# Control course view options globally
+VIEWS_DISABLED=

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ The bq_cred.json is service account for Big Query, it needs to be supplied and p
 	student-dashboard-saml.key
 	student-dashboard-saml.pem
 
+# Control course view options
+
+View options can be controlled at the global and course level. If a view is disabled globally, it will be disabled for each course, even if previously enabled at the course level. If a view is not globally disabled, it can still be disabled at the course level.
+
+`VIEWS_DISABLED` comma delimited list of views to disable (default empty). The expected name of the view is the same as the view's column name in the `course_view_option` table. Example value of `show_files_accessed,show_grade_distribution` will disable both the Files Accessed and Grade Distribution views.
+
+Note that by default all views are enabled when a course is added.
+
 # LTI v1.1.1 Configuration
 
 Only basic LTI launches are supported at the moment (automatic account creation and redirection to the correct course). New courses are not added nor are course view options modified.

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -11,6 +11,13 @@ class CourseInline(admin.TabularInline):
 class CourseViewOptionInline(admin.StackedInline):
     model = CourseViewOption
 
+    exclude = ()
+
+    # exclude disabled views
+    for view in CourseViewOption.VIEWS:
+        if view in settings.VIEWS_DISABLED:
+            exclude += (view,)
+
 class CourseAdmin(admin.ModelAdmin):
     inlines = [CourseViewOptionInline,]
     list_display = ('name', 'term_id','_courseviewoption')

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -43,9 +43,9 @@ def get_course_view_options (course_id):
             row = cursor.fetchone()
             if (row != None):
                 course_view_option = {}
-                course_view_option['show_files_accessed'] = row[0]
-                course_view_option['show_assignment_planning'] = row[1]
-                course_view_option['show_grade_distribution'] = row[2]
+                course_view_option['show_files_accessed'] = row[0] and 'show_files_accessed' not in settings.VIEWS_DISABLED
+                course_view_option['show_assignment_planning'] = row[1] and 'show_assignment_planning' not in settings.VIEWS_DISABLED
+                course_view_option['show_grade_distribution'] = row[2] and 'show_grade_distribution' not in settings.VIEWS_DISABLED
     return course_view_option
 
 def get_default_user_course_id(user_id):

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -418,10 +418,11 @@ class DashboardCronJob(CronJobBase):
 
         status += self.submission()
         status += self.weight_consideration()
-
+        
         logger.info("** file")
-        status += self.update_with_udw_file()
-        status += self.update_with_bq_access()
+        if 'show_files_accessed' not in settings.VIEWS_DISABLED:
+            status += self.update_with_udw_file()
+            status += self.update_with_bq_access()
 
         logger.info("** informational")
         status += self.update_unizin_metadata()

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -8,8 +8,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.core.exceptions import ObjectDoesNotExist
-
+from django.conf import settings
 import logging
 logger = logging.getLogger(__name__)
 
@@ -180,15 +179,17 @@ class Course(models.Model):
 
 class CourseViewOption(models.Model):
     course = models.OneToOneField(Course, on_delete=models.CASCADE, primary_key=True, verbose_name="Course View Option Id")
-    show_files_accessed = models.BooleanField(blank=False, null=False, verbose_name="Show Files Accessed View")
-    show_assignment_planning = models.BooleanField(blank=False, null=False, verbose_name="Show Assignment Planning View")
-    show_grade_distribution = models.BooleanField(blank=False, null=False, verbose_name="Show Grade Distribution View")
+    show_files_accessed = models.BooleanField(blank=False, null=False, default=True, verbose_name="Show Files Accessed View")
+    show_assignment_planning = models.BooleanField(blank=False, null=False, default=True, verbose_name="Show Assignment Planning View")
+    show_grade_distribution = models.BooleanField(blank=False, null=False, default=True, verbose_name="Show Grade Distribution View")
+
+    VIEWS = ['show_files_accessed', 'show_assignment_planning', 'show_grade_distribution']
 
     def __str__(self):
         retval = ""
-        if self.show_files_accessed: retval += "Files Accessed\n"
-        if self.show_assignment_planning: retval += "Assignment Planning\n"
-        if self.show_grade_distribution: retval += "Grade Distribution\n"
+        if self.show_files_accessed and 'show_files_accessed' not in settings.VIEWS_DISABLED: retval += "Files Accessed\n"
+        if self.show_assignment_planning and 'show_assignment_planning' not in settings.VIEWS_DISABLED: retval += "Assignment Planning\n"
+        if self.show_grade_distribution and 'show_grade_distribution' not in settings.VIEWS_DISABLED: retval += "Grade Distribution\n"
         return retval
 
     class Meta:
@@ -207,9 +208,9 @@ class CourseViewOption(models.Model):
         try:
             return {
                 self.course.canvas_id: {
-                    'fa': int(self.show_files_accessed),
-                    'ap': int(self.show_assignment_planning),
-                    'gd': int(self.show_grade_distribution),
+                    'fa': int(self.show_files_accessed and 'show_files_accessed' not in settings.VIEWS_DISABLED),
+                    'ap': int(self.show_assignment_planning and 'show_assignment_planning' not in settings.VIEWS_DISABLED),
+                    'gd': int(self.show_grade_distribution and 'show_grade_distribution' not in settings.VIEWS_DISABLED),
                 }
             }
         except ObjectDoesNotExist:

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -345,6 +345,9 @@ UDW_ID_PREFIX = config("UDW_ID_PREFIX", default="17700000000", cast=str)
 # This is fixed from UDW
 UDW_FILE_ID_PREFIX = config("UDW_FILE_ID_PREFIX", default="1770000000")
 
+# Allow enabling/disabling the View options globally
+VIEWS_DISABLED = config('VIEWS_DISABLED', default='', cast=Csv())
+
 # This is to set a date so that MyLA will track all terms with start date after this date.
 
 EARLIEST_TERM_DATE = config('EARLIEST_TERM_DATE', default='2016-11-15')


### PR DESCRIPTION
- Each of the view options (files accessed, assignment planning, and grade distribution) can now be disabled globally via the VIEWS_DISABLED environment variable.
- If files accessed is disabled, will no longer attempt to collect data file date from Canvas Data or big query
- Admin course view options will hide disabled view options
- added default value of true for course view options