### PR TITLE
Support non-unizin Canvas Data sources

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,24 +35,27 @@ MYSQL_PORT=3306
 # Local database root password (optional)
 MYSQL_ROOT_PASSWORD=student_dashboard_root_pw
 
-# UDW configuration
-# UDW database engine
-UDW_ENGINE=django.db.backends.postgresql
-# UDW database name
-UDW_DATABASE=
-# UDW database user
-UDW_USER=
-# UDW database password
-UDW_PASSWORD=
-# UDW database host (previously UDW_ENDPOINT)
-UDW_HOST=
-# UDW database port
-UDW_PORT=
+# Data Warehouse configuration
+# database engine
+DATA_WAREHOUSE_ENGINE=django.db.backends.postgresql
+# database name
+DATA_WAREHOUSE_DATABASE=
+# database user
+DATA_WAREHOUSE_USER=
+# database password
+DATA_WAREHOUSE_PASSWORD=
+# database host
+DATA_WAREHOUSE_HOST=
+# database port
+DATA_WAREHOUSE_PORT=
 
-# Default UDW prefix for course id, user id, etc
-UDW_ID_PREFIX=
-# default UDW file prefix for file id
-UDW_FILE_ID_PREFIX=
+# Enable/Disable Unizin Date Warehouse specific features/data
+DATA_WAREHOUSE_IS_UNIZIN=True
+
+# Default Data Warehouse prefix for course id, user id, etc
+DATA_WAREHOUSE_ID_PREFIX=
+# default Data Warehouse file prefix for file id
+DATA_WAREHOUSE_FILE_ID_PREFIX=
 
 # Canvas Configuration
 CANVAS_USER=
@@ -105,10 +108,6 @@ DJANGO_SAML2_DEFAULT_IDP=
 
 # Earliest term date from database that we'll show and support academic terms from (default is 2016-11-15 which the first date of 'our' data)
 EARLIEST_TERM_DATE=
-
-
-# This is fixed from UDW
-UDW_ID_PREFIX =
 
 ### CRON POD SETTINGS
 #

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -30,7 +30,7 @@ class CourseAdmin(admin.ModelAdmin):
 
     # When saving the course, update the id based on canvas id
     def save_model(self, request, obj, form, change):
-        obj.id = settings.UDW_ID_PREFIX + obj.canvas_id
+        obj.id = settings.DATA_WAREHOUSE_ID_PREFIX + obj.canvas_id
         return super(CourseAdmin, self).save_model(request, obj, form, change)
         
 admin.site.register (Course, CourseAdmin)

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -14,14 +14,14 @@ logger = logging.getLogger(__name__)
 
 def get_course_name_from_id(course_id):
     """[Get the long course name from the id]
-    
-    :param course_id: [Canvas course ID without UDW PREFIX]
+
+    :param course_id: [Canvas course ID without DATA_WAREHOUSE PREFIX]
     :type course_id: [str]
     :return: [Course Name of course or blank not found]
     :rtype: [str]
     """
     logger.info(get_course_name_from_id.__name__)
-    course_id = settings.UDW_ID_PREFIX + str(course_id)
+    course_id = settings.DATA_WAREHOUSE_ID_PREFIX + str(course_id)
     course_name = ""
     if (course_id):
         with django.db.connection.cursor() as cursor:
@@ -34,7 +34,7 @@ def get_course_name_from_id(course_id):
 def get_course_view_options (course_id):
 
     logger.info(get_course_view_options.__name__)
-    course_id = settings.UDW_ID_PREFIX + str(course_id)
+    course_id = settings.DATA_WAREHOUSE_ID_PREFIX + str(course_id)
     logger.debug("course_id=" + str(course_id))
     course_view_option = ""
     if (course_id):
@@ -61,8 +61,8 @@ def get_default_user_course_id(user_id):
         cursor.execute("SELECT course_id FROM user WHERE sis_name= %s ORDER BY course_id DESC LIMIT 1", [user_id])
         row = cursor.fetchone()
         if (row != None):
-            #Remove the UDW_ID_PREFIX and just return the course_id
-            course_id = str(row[0]).replace(settings.UDW_ID_PREFIX, "")
+            #Remove the DATA_WAREHOUSE_ID_PREFIX and just return the course_id
+            course_id = str(row[0]).replace(settings.DATA_WAREHOUSE_ID_PREFIX, "")
     return course_id
 
 def get_last_cron_run():
@@ -75,6 +75,9 @@ def get_last_cron_run():
     return datetime.min
 
 def get_canvas_data_date():
+    if not settings.DATA_WAREHOUSE_IS_UNIZIN:
+        return get_last_cron_run()
+
     try:
         with django.db.connection.cursor() as cursor:
             cursor.execute("SELECT pvalue from unizin_metadata where pkey = 'canvasdatadate'")

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -41,13 +41,13 @@ def split_list(a_list: list, size: int = 20):
     return [a_list[i:i + size] for i in range(0, len(a_list), size)]
 
 # the util function
-def util_function(udw_course_id, sql_string, mysql_table, table_identifier=None):
-    df = pd.read_sql(sql_string, conns['UDW'])
+def util_function(data_warehouse_course_id, sql_string, mysql_table, table_identifier=None):
+    df = pd.read_sql(sql_string, conns['DATA_WAREHOUSE'])
     logger.debug(df)
 
     # Sql returns boolean value so grouping course info along with it so that this could be stored in the DB table.
-    if table_identifier == 'weight' and udw_course_id:
-        df['course_id']=udw_course_id
+    if table_identifier == 'weight' and data_warehouse_course_id:
+        df['course_id']=data_warehouse_course_id
         df.columns=['consider_weight','course_id']
 
     # drop duplicates
@@ -63,7 +63,7 @@ def util_function(udw_course_id, sql_string, mysql_table, table_identifier=None)
         raise
 
     # returns the row size of dataframe
-    return f"{str(df.shape[0])} {mysql_table} : {udw_course_id}\n"
+    return f"{str(df.shape[0])} {mysql_table} : {data_warehouse_course_id}\n"
 
 # execute database query
 def executeDbQuery(query):
@@ -99,12 +99,12 @@ class DashboardCronJob(CronJobBase):
                 invalid_course_id_list.append(course_id)
             else:
                 # select course based on course id
-                course_sql = f"""select * 
+                course_sql = f"""select *
                             from course_dim c
                             where c.id = '{course_id}'
                             """
                 logger.debug(course_sql)
-                course_df = pd.read_sql(course_sql, conns['UDW'])
+                course_df = pd.read_sql(course_sql, conns['DATA_WAREHOUSE'])
 
                 # error out when course id is invalid
                 if course_df.empty:
@@ -114,47 +114,47 @@ class DashboardCronJob(CronJobBase):
 
         return invalid_course_id_list
 
-    # update USER records from UDW
-    def update_with_udw_user(self):
+    # update USER records from DATA_WAREHOUSE
+    def update_user(self):
 
         # cron status
         status = ""
 
-        logger.debug("in update with udw user")
+        logger.debug("in update with data warehouse user")
 
         # delete all records in the table first
         status += deleteAllRecordInTable("user")
 
         # loop through multiple course ids
-        for udw_course_id in Course.objects.get_supported_courses():
+        for data_warehouse_course_id in Course.objects.get_supported_courses():
 
             # select all student registered for the course
-            user_sql = f"""select u.name AS name, 
-                        p.sis_user_id AS sis_id, 
-                        p.unique_name AS sis_name, 
-                        u.global_canvas_id AS id, 
-                        c.current_score AS current_grade, 
-                        c.final_score AS final_grade, 
-                        '{udw_course_id}' as course_id 
-                        from user_dim u, 
-                        pseudonym_dim p, 
-                        course_score_fact c, 
-                        (select e.user_id as user_id, e.id as enrollment_id from enrollment_dim e 
-                        where e.course_id = '{udw_course_id}' 
-                        and e.type='StudentEnrollment' 
-                        and e.workflow_state='active' ) as e 
-                        where p.user_id=u.id 
-                        and u.id = e.user_id 
-                        and c.enrollment_id =  e.enrollment_id 
+            user_sql = f"""select u.name AS name,
+                        p.sis_user_id AS sis_id,
+                        p.unique_name AS sis_name,
+                        u.global_canvas_id AS id,
+                        c.current_score AS current_grade,
+                        c.final_score AS final_grade,
+                        '{data_warehouse_course_id}' as course_id
+                        from user_dim u,
+                        pseudonym_dim p,
+                        course_score_fact c,
+                        (select e.user_id as user_id, e.id as enrollment_id from enrollment_dim e
+                        where e.course_id = '{data_warehouse_course_id}'
+                        and e.type='StudentEnrollment'
+                        and e.workflow_state='active' ) as e
+                        where p.user_id=u.id
+                        and u.id = e.user_id
+                        and c.enrollment_id =  e.enrollment_id
                         and p.sis_user_id is not null
                         """
             logger.debug(user_sql)
 
-            status += util_function(udw_course_id, user_sql, 'user')
+            status += util_function(data_warehouse_course_id, user_sql, 'user')
 
         return status
 
-    # update unizin metadata from UDW
+    # update unizin metadata from DATA_WAREHOUSE
     def update_unizin_metadata(self):
 
         # cron status
@@ -176,23 +176,23 @@ class DashboardCronJob(CronJobBase):
 
 
 
-    # update file records from UDW
-    def update_with_udw_file(self):
+    # update file records from DATA_WAREHOUSE
+    def update_file(self):
         # cron status
         status = ""
 
-        logger.debug("in update with udw file")
+        logger.debug("in update with data warehouse file")
 
         # delete all records in the table first
         status += deleteAllRecordInTable("file")
 
-        #select file record from UDW
-        for udw_course_id in Course.objects.get_supported_courses():
-            file_sql = f"""select id, display_name as name,course_id as COURSE_ID from file_dim where file_state ='available' 
-                           and course_id='{udw_course_id}'
+        #select file record from DATA_WAREHOUSE
+        for data_warehouse_course_id in Course.objects.get_supported_courses():
+            file_sql = f"""select id, display_name as name,course_id as COURSE_ID from file_dim where file_state ='available'
+                           and course_id='{data_warehouse_course_id}'
                         """
 
-            status += util_function(udw_course_id, file_sql, 'file')
+            status += util_function(data_warehouse_course_id, file_sql, 'file')
         return status
 
     # update FILE_ACCESS records from BigQuery
@@ -215,7 +215,7 @@ class DashboardCronJob(CronJobBase):
 
         # loop through multiple course ids, 20 at a time
         # (This is set by the CRON_BQ_IN_LIMIT from settings)
-        for udw_course_ids in split_list(Course.objects.get_supported_courses(), settings.CRON_BQ_IN_LIMIT):
+        for data_warehouse_course_ids in split_list(Course.objects.get_supported_courses(), settings.CRON_BQ_IN_LIMIT):
             # query to retrieve all file access events for one course
             # There is no catch if this query fails, event_store.events needs to exist
             query = """select CAST(SUBSTR(JSON_EXTRACT_SCALAR(event, '$.object.id'), 35) AS STRING) AS file_id,
@@ -230,9 +230,9 @@ class DashboardCronJob(CronJobBase):
                     and SUBSTR(JSON_EXTRACT_SCALAR(event, "$.group.id"),31) IN UNNEST(@course_ids)
                     """
             logger.debug(query)
-            logger.debug(udw_course_ids)
+            logger.debug(data_warehouse_course_ids)
             query_params = [
-                bigquery.ArrayQueryParameter('course_ids', 'STRING', udw_course_ids),
+                bigquery.ArrayQueryParameter('course_ids', 'STRING', data_warehouse_course_ids),
             ]
             job_config = bigquery.QueryJobConfig()
             job_config.query_parameters = query_params
@@ -252,7 +252,7 @@ class DashboardCronJob(CronJobBase):
             # write to MySQL
             df.to_sql(con=engine, name='file_access', if_exists='append', index=False)
 
-            return_string += str(df.shape[0]) + " rows for courses " + ",".join(udw_course_ids) + "\n"
+            return_string += str(df.shape[0]) + " rows for courses " + ",".join(data_warehouse_course_ids) + "\n"
             logger.info(return_string)
 
         total_tbytes_billed = total_bytes_billed / 1024 / 1024 / 1024 / 1024
@@ -271,18 +271,18 @@ class DashboardCronJob(CronJobBase):
         # update groups
         #Loading the assignment groups inforamtion along with weight/points associated ith arn assignment
         logger.debug("update_assignment_groups(): ")
-        
+
         # loop through multiple course ids
-        for udw_course_id in Course.objects.get_supported_courses():
-            assignment_groups_sql = f"""with assignment_details as (select ad.due_at,ad.title,af.course_id ,af.assignment_id,af.points_possible,af.assignment_group_id from assignment_fact af inner join assignment_dim ad on af.assignment_id = ad.id where af.course_id='{udw_course_id}' and ad.visibility = 'everyone' and ad.workflow_state='published'),
-                                    assignment_grp as (select agf.*, agd.name from assignment_group_dim agd join assignment_group_fact agf on agd.id = agf.assignment_group_id  where agd.course_id='{udw_course_id}' and workflow_state='available'),
+        for data_warehouse_course_id in Course.objects.get_supported_courses():
+            assignment_groups_sql = f"""with assignment_details as (select ad.due_at,ad.title,af.course_id ,af.assignment_id,af.points_possible,af.assignment_group_id from assignment_fact af inner join assignment_dim ad on af.assignment_id = ad.id where af.course_id='{data_warehouse_course_id}' and ad.visibility = 'everyone' and ad.workflow_state='published'),
+                                    assignment_grp as (select agf.*, agd.name from assignment_group_dim agd join assignment_group_fact agf on agd.id = agf.assignment_group_id  where agd.course_id='{data_warehouse_course_id}' and workflow_state='available'),
                                     assign_more as (select distinct(a.assignment_group_id) ,da.group_points from assignment_details a join (select assignment_group_id, sum(points_possible) as group_points from assignment_details group by assignment_group_id) as da on a.assignment_group_id = da.assignment_group_id ),
                                     assign_rules as (select DISTINCT ad.assignment_group_id,agr.drop_lowest,agr.drop_highest from assignment_details ad join assignment_group_rule_dim agr on ad.assignment_group_id=agr.assignment_group_id),
                                     assignment_grp_points as (select ag.*, am.group_points AS group_points from assignment_grp ag join assign_more am on ag.assignment_group_id = am.assignment_group_id),
                                     assign_final as (select assignment_group_id AS id, course_id AS course_id, group_weight AS weight, name AS name, group_points AS group_points from assignment_grp_points)
                                     select g.*, ar.drop_lowest,ar.drop_highest from assign_rules ar join assign_final g on ar.assignment_group_id=g.id
                                     """
-            status += util_function(udw_course_id, assignment_groups_sql, 'assignment_groups')
+            status += util_function(data_warehouse_course_id, assignment_groups_sql, 'assignment_groups')
 
         return status
 
@@ -296,16 +296,16 @@ class DashboardCronJob(CronJobBase):
         status += deleteAllRecordInTable("assignment")
 
         # loop through multiple course ids
-        for udw_course_id in Course.objects.get_supported_courses():
+        for data_warehouse_course_id in Course.objects.get_supported_courses():
             assignment_sql = f"""with assignment_info as
                             (select ad.due_at AS due_date,ad.due_at at time zone 'utc' at time zone 'America/New_York' as local_date,
                             ad.title AS name,af.course_id AS course_id,af.assignment_id AS id,
                             af.points_possible AS points_possible,af.assignment_group_id AS assignment_group_id
-                            from assignment_fact af inner join assignment_dim ad on af.assignment_id = ad.id where af.course_id='{udw_course_id}' 
+                            from assignment_fact af inner join assignment_dim ad on af.assignment_id = ad.id where af.course_id='{data_warehouse_course_id}'
                             and ad.visibility = 'everyone' and ad.workflow_state='published')
                             select * from assignment_info
                             """
-            status += util_function(udw_course_id, assignment_sql,'assignment')
+            status += util_function(data_warehouse_course_id, assignment_sql,'assignment')
 
         return status
 
@@ -321,17 +321,17 @@ class DashboardCronJob(CronJobBase):
         status += deleteAllRecordInTable("submission")
 
         # loop through multiple course ids
-        for udw_course_id in Course.objects.get_supported_courses():
-            submission_url = f"""with sub_fact as (select submission_id, assignment_id, course_id, user_id, global_canvas_id, published_score from submission_fact sf join user_dim u on sf.user_id = u.id where course_id = '{udw_course_id}'),
-                             enrollment as (select  distinct(user_id) from enrollment_dim where course_id = '{udw_course_id}' and workflow_state='active' and type = 'StudentEnrollment'),
+        for data_warehouse_course_id in Course.objects.get_supported_courses():
+            submission_url = f"""with sub_fact as (select submission_id, assignment_id, course_id, user_id, global_canvas_id, published_score from submission_fact sf join user_dim u on sf.user_id = u.id where course_id = '{data_warehouse_course_id}'),
+                             enrollment as (select  distinct(user_id) from enrollment_dim where course_id = '{data_warehouse_course_id}' and workflow_state='active' and type = 'StudentEnrollment'),
                              sub_with_enroll as (select sf.* from sub_fact sf join enrollment e on e.user_id = sf.user_id),
                              submission_time as (select sd.id, sd.graded_at from submission_dim sd join sub_fact suf on sd.id=suf.submission_id),
-                             assign_fact as (select s.*,a.title from assignment_dim a join sub_with_enroll s on s.assignment_id=a.id where a.course_id='{udw_course_id}' and a.workflow_state='published' and muted = false),
+                             assign_fact as (select s.*,a.title from assignment_dim a join sub_with_enroll s on s.assignment_id=a.id where a.course_id='{data_warehouse_course_id}' and a.workflow_state='published' and muted = false),
                              assign_sub_time as (select a.*, t.graded_at from assign_fact a join submission_time t on a.submission_id = t.id),
                              all_assign_sub as (select submission_id AS id, assignment_id AS assignment_id, course_id, global_canvas_id AS user_id, published_score AS score, graded_at AS graded_date from assign_sub_time order by assignment_id)
                              select f.*, f1.avg_score from all_assign_sub f join (select assignment_id, round(avg(score),1) as avg_score from all_assign_sub group by assignment_id) as f1 on f.assignment_id = f1.assignment_id
                              """
-            status += util_function(udw_course_id, submission_url,'submission')
+            status += util_function(data_warehouse_course_id, submission_url,'submission')
 
         return status
 
@@ -347,27 +347,27 @@ class DashboardCronJob(CronJobBase):
         status += deleteAllRecordInTable("assignment_weight_consideration")
 
         # loop through multiple course ids
-        for udw_course_id in Course.objects.get_supported_courses():
+        for data_warehouse_course_id in Course.objects.get_supported_courses():
             is_weight_considered_url = f"""with course as (select course_id, sum(group_weight) as group_weight from assignment_group_fact
-                                        where course_id = '{udw_course_id}' group by course_id having sum(group_weight)>1)
+                                        where course_id = '{data_warehouse_course_id}' group by course_id having sum(group_weight)>1)
                                         (select CASE WHEN EXISTS (SELECT * FROM course WHERE group_weight > 1) THEN CAST(1 AS BOOLEAN) ELSE CAST(0 AS BOOLEAN) END)
                                         """
-            status += util_function(udw_course_id, is_weight_considered_url,'assignment_weight_consideration', 'weight')
+            status += util_function(data_warehouse_course_id, is_weight_considered_url,'assignment_weight_consideration', 'weight')
 
             logger.debug(status+"\n\n")
 
         return status
 
-    def update_with_udw_term(self):
+    def update_term(self):
         # cron status
         status = ""
 
-        logger.debug("in update with udw term")
+        logger.debug("in update with data warehouse term")
 
         # delete all records in the table first
         status += deleteAllRecordInTable("academic_terms")
 
-        #select file record from UDW
+        #select term records from DATA_WAREHOUSE
         term_sql = f"select id, canvas_id, name, date_start, date_end from enrollment_term_dim where date_start > '{settings.EARLIEST_TERM_DATE}'"
         logger.debug(term_sql)
         status += util_function(None, term_sql, 'academic_terms')
@@ -393,10 +393,10 @@ class DashboardCronJob(CronJobBase):
         # continue cron tasks
 
         logger.info("** term")
-        status += self.update_with_udw_term()
+        status += self.update_term()
 
         logger.info("** user")
-        status += self.update_with_udw_user()
+        status += self.update_user()
 
         logger.info("** assignment")
         status += self.update_groups()
@@ -404,14 +404,15 @@ class DashboardCronJob(CronJobBase):
 
         status += self.submission()
         status += self.weight_consideration()
-        
+
         logger.info("** file")
         if 'show_files_accessed' not in settings.VIEWS_DISABLED:
-            status += self.update_with_udw_file()
+            status += self.update_file()
             status += self.update_with_bq_access()
 
-        logger.info("** informational")
-        status += self.update_unizin_metadata()
+        if settings.DATA_WAREHOUSE_IS_UNIZIN:
+            logger.info("** informational")
+            status += self.update_unizin_metadata()
 
         status += "End cron: " +  str(datetime.datetime.now()) + "\n"
 

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -130,13 +130,13 @@ DATABASES = {
         'HOST': config('MYSQL_HOST', default='localhost'),
         'PORT': config('MYSQL_PORT', default=3306, cast=int),
     },
-    'UDW': {
-        'ENGINE': config('UDW_ENGINE', default='django.db.backends.postgresql'),
-        'NAME': config('UDW_DATABASE', default=''),
-        'USER': config('UDW_USER', default=''),
-        'PASSWORD': config('UDW_PASSWORD', default=''),
-        'HOST': config('UDW_HOST', default=config('UDW_ENDPOINT', default='')),
-        'PORT': config('UDW_PORT', default=5432, cast=int),
+    'DATA_WAREHOUSE': {
+        'ENGINE': config('DATA_WAREHOUSE_ENGINE', default='django.db.backends.postgresql'),
+        'NAME': config('DATA_WAREHOUSE_DATABASE', default=''),
+        'USER': config('DATA_WAREHOUSE_USER', default=''),
+        'PASSWORD': config('DATA_WAREHOUSE_PASSWORD', default=''),
+        'HOST': config('DATA_WAREHOUSE_HOST', default=''),
+        'PORT': config('DATA_WAREHOUSE_PORT', default=5432, cast=int),
     }
 }
 
@@ -339,11 +339,14 @@ if config('STUDENT_DASHBOARD_LTI', default='False', cast=bool):
     LTI_CANVAS_COURSE_ID_FIELD = config('LTI_CANVAS_COURSE_ID_FIELD',
         default="custom_canvas_course_id", cast=str)
 
-# This is fixed from UDW
-UDW_ID_PREFIX = config("UDW_ID_PREFIX", default="17700000000", cast=str)
+# controls whether Unizin specific features/data is available from the Canvas Data source
+DATA_WAREHOUSE_IS_UNIZIN = config("DATA_WAREHOUSE_IS_UNIZIN", default=True, cast=bool)
 
-# This is fixed from UDW
-UDW_FILE_ID_PREFIX = config("UDW_FILE_ID_PREFIX", default="1770000000")
+# This is fixed from DATA_WAREHOUSE
+DATA_WAREHOUSE_ID_PREFIX = config("DATA_WAREHOUSE_ID_PREFIX", default="17700000000", cast=str)
+
+# This is fixed from DATA_WAREHOUSE
+DATA_WAREHOUSE_FILE_ID_PREFIX = config("DATA_WAREHOUSE_FILE_ID_PREFIX", default="1770000000")
 
 # Allow enabling/disabling the View options globally
 VIEWS_DISABLED = config('VIEWS_DISABLED', default='', cast=Csv())
@@ -356,7 +359,7 @@ EARLIEST_TERM_DATE = config('EARLIEST_TERM_DATE', default='2016-11-15')
 RUN_AT_TIMES = config('RUN_AT_TIMES', default="", cast= Csv())
 
 # Add any settings you need to be available to templates in this array
-SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID', 'UDW_ID_PREFIX']
+SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID', 'DATA_WAREHOUSE_ID_PREFIX']
 
 # Method to show the user, if they're authenticated and superuser
 def show_debug_toolbar(request):

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -68,7 +68,7 @@
 <script>
 // Setup a top level js object to hold global values
 var dashboard = {
-{% if course_id %}"course_id": '{{settings.UDW_ID_PREFIX}}'+'{{ course_id }}',
+{% if course_id %}"course_id": '{{settings.DATA_WAREHOUSE_ID_PREFIX}}'+'{{ course_id }}',
 {% else %}"course_id": 0,
 {% endif %}
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,6 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_PORT=${MYSQL_PORT}
-
-      - UDW_ENDPOINT=${UDW_ENDPOINT}
-      - UDW_USER=${UDW_USER}
-      - UDW_PASSWORD=${UDW_PASSWORD}
-      - UDW_PORT=${UDW_PORT}
-      - UDW_DATABASE=${UDW_DATABASE}
     entrypoint: ['docker-entrypoint.sh', '--default-authentication-plugin=mysql_native_password']
     ports:
       - "5306:3306"


### PR DESCRIPTION
- Renames UDW to DATA_WAREHOUSE to be more data source generic
- adds env variable to disable unizin only features/data. Currently is this only the `unizin_metadata` table and the Canvas Data last update datetime (falling back unto last cron run for now)
- removes UDW environment variables from mysql container in docker compose file