### PR TITLE
Refactor canvas id prefixing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -52,10 +52,8 @@ DATA_WAREHOUSE_PORT=
 # Enable/Disable Unizin Date Warehouse specific features/data
 DATA_WAREHOUSE_IS_UNIZIN=True
 
-# Default Data Warehouse prefix for course id, user id, etc
-DATA_WAREHOUSE_ID_PREFIX=
-# default Data Warehouse file prefix for file id
-DATA_WAREHOUSE_FILE_ID_PREFIX=
+# Default Canvas Data id increment for course id, user id, etc
+CANVAS_DATA_ID_INCREMENT=17700000000000000
 
 # Canvas Configuration
 CANVAS_USER=

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.template.defaultfilters import linebreaksbr
 
+from dashboard.common.db_util import canvas_id_to_incremented_id
 from .models import CourseViewOption, Course
 
 class CourseInline(admin.TabularInline):
@@ -30,7 +31,7 @@ class CourseAdmin(admin.ModelAdmin):
 
     # When saving the course, update the id based on canvas id
     def save_model(self, request, obj, form, change):
-        obj.id = settings.DATA_WAREHOUSE_ID_PREFIX + obj.canvas_id
+        obj.id = canvas_id_to_incremented_id(obj.canvas_id)
         return super(CourseAdmin, self).save_model(request, obj, form, change)
         
 admin.site.register (Course, CourseAdmin)

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -12,16 +12,32 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
+def canvas_id_to_incremented_id(canvas_id):
+    try:
+        int(canvas_id)
+    except ValueError:
+        return None
+
+    return str(int(canvas_id) + settings.CANVAS_DATA_ID_INCREMENT)
+
+def incremented_id_to_canvas_id(incremented_id):
+    try:
+        int(incremented_id)
+    except ValueError:
+        return None
+
+    return str(int(incremented_id) - settings.CANVAS_DATA_ID_INCREMENT)
+
 def get_course_name_from_id(course_id):
     """[Get the long course name from the id]
 
-    :param course_id: [Canvas course ID without DATA_WAREHOUSE PREFIX]
+    :param course_id: [Canvas course ID without the Canvas Data increment]
     :type course_id: [str]
     :return: [Course Name of course or blank not found]
     :rtype: [str]
     """
     logger.info(get_course_name_from_id.__name__)
-    course_id = settings.DATA_WAREHOUSE_ID_PREFIX + str(course_id)
+    course_id = canvas_id_to_incremented_id(course_id)
     course_name = ""
     if (course_id):
         with django.db.connection.cursor() as cursor:
@@ -34,7 +50,7 @@ def get_course_name_from_id(course_id):
 def get_course_view_options (course_id):
 
     logger.info(get_course_view_options.__name__)
-    course_id = settings.DATA_WAREHOUSE_ID_PREFIX + str(course_id)
+    course_id = canvas_id_to_incremented_id(course_id)
     logger.debug("course_id=" + str(course_id))
     course_view_option = ""
     if (course_id):
@@ -61,8 +77,7 @@ def get_default_user_course_id(user_id):
         cursor.execute("SELECT course_id FROM user WHERE sis_name= %s ORDER BY course_id DESC LIMIT 1", [user_id])
         row = cursor.fetchone()
         if (row != None):
-            #Remove the DATA_WAREHOUSE_ID_PREFIX and just return the course_id
-            course_id = str(row[0]).replace(settings.DATA_WAREHOUSE_ID_PREFIX, "")
+            course_id = canvas_id_to_incremented_id(row[0])
     return course_id
 
 def get_last_cron_run():

--- a/dashboard/context_processors.py
+++ b/dashboard/context_processors.py
@@ -35,6 +35,13 @@ def course_view_option(request):
 
     return {"course_view_option": course_view_option}
 
+def current_user_incremented_course_id(request):
+    course_id = str(request.resolver_match.kwargs.get('course_id'))
+    if not course_id:
+        logger.info(f"Course ID could not be determined from request, attempting to look up for user {request.user.username}")
+        course_id = db_util.get_default_user_course_id(request.user.username)
+    incremented_course_id = db_util.canvas_id_to_incremented_id(course_id)
+    return {'current_user_incremented_course_id': incremented_course_id}
 
 def last_updated(request):
     return {'last_updated': db_util.get_canvas_data_date()}

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -144,7 +144,7 @@ class CourseQuerySet(models.QuerySet):
         """Returns the list of supported courses from the database
         
         :return: [List of supported course ids]
-        :rtype: [list of str (possibly prefixed depending on parameter)]
+        :rtype: [list of str (possibly incremented depending on parameter)]
         """
         try:
             return self.values_list('id', flat=True)

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -105,6 +105,7 @@ TEMPLATES = [
                 'django_settings_export.settings_export',
                 'dashboard.context_processors.course_name',
                 'dashboard.context_processors.current_user_course_id',
+                'dashboard.context_processors.current_user_incremented_course_id',
                 'dashboard.context_processors.course_view_option',
                 'dashboard.context_processors.last_updated',
                 'dashboard.context_processors.get_build_info',
@@ -342,11 +343,8 @@ if config('STUDENT_DASHBOARD_LTI', default='False', cast=bool):
 # controls whether Unizin specific features/data is available from the Canvas Data source
 DATA_WAREHOUSE_IS_UNIZIN = config("DATA_WAREHOUSE_IS_UNIZIN", default=True, cast=bool)
 
-# This is fixed from DATA_WAREHOUSE
-DATA_WAREHOUSE_ID_PREFIX = config("DATA_WAREHOUSE_ID_PREFIX", default="17700000000", cast=str)
-
-# This is fixed from DATA_WAREHOUSE
-DATA_WAREHOUSE_FILE_ID_PREFIX = config("DATA_WAREHOUSE_FILE_ID_PREFIX", default="1770000000")
+# This is used to fix ids from Canvas Data which are incremented by some large number
+CANVAS_DATA_ID_INCREMENT = config("CANVAS_DATA_ID_INCREMENT", default="17700000000000000", cast=int)
 
 # Allow enabling/disabling the View options globally
 VIEWS_DISABLED = config('VIEWS_DISABLED', default='', cast=Csv())
@@ -359,7 +357,7 @@ EARLIEST_TERM_DATE = config('EARLIEST_TERM_DATE', default='2016-11-15')
 RUN_AT_TIMES = config('RUN_AT_TIMES', default="", cast= Csv())
 
 # Add any settings you need to be available to templates in this array
-SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID', 'DATA_WAREHOUSE_ID_PREFIX']
+SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID']
 
 # Method to show the user, if they're authenticated and superuser
 def show_debug_toolbar(request):

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -68,7 +68,7 @@
 <script>
 // Setup a top level js object to hold global values
 var dashboard = {
-{% if course_id %}"course_id": '{{settings.DATA_WAREHOUSE_ID_PREFIX}}'+'{{ course_id }}',
+{% if course_id %}"course_id": '{{ current_user_incremented_course_id }}',
 {% else %}"course_id": 0,
 {% endif %}
 };


### PR DESCRIPTION
- Switched from prefixing canvas ids to incrementing the id by a set integer from the `CANVAS_DATA_ID_INCREMENT` environment variable.
- This handles how Canvas Data creates their ids better
- DATA_WAREHOUSE_FILE_ID_PREFIX and DATA_WAREHOUSE_ID_PREFIX are removed (instead CANVAS_DATA_ID_INCREMENT is used)

Note: this is a breaking change to how `DATA_WAREHOUSE_ID_PREFIX` worked. Existing installation will need to update the value with the correct canvas id increment.

Depends on PR #349