### PR TITLE
Fix docker compose prod mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - .:/code
       # use the container's node_modules folder (don't override)
       - /code/node_modules/
+      - /code/static/
     ports:
       - "5001:5000"
       - "3000:3000"


### PR DESCRIPTION
static files are needed when `DEBUG=false`

Closes #405