### PR TITLE
Update NOTICE for UBC

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,4 +3,4 @@ Copyright © 2018-2019 The Regents of the University of Michigan
 
 This product includes software developed at
 ITS Teaching and Learning, University of Michigan (https://its.umich.edu/teaching-learning).
-Teaching & Learning Technologies, The University of British Columbia (https://ctlt.ubc.ca/about/contact-us/teaching-learning-technologies/).
+The University of British Columbia (https://learninganalytics.ubc.ca/).


### PR DESCRIPTION
Modified to `The University of British Columbia` and added link to UBC Learning Analytics website.