### PR TITLE
Fix error when data is an empty object

### DIFF
--- a/assets/src/containers/AssignmentPlanning.js
+++ b/assets/src/containers/AssignmentPlanning.js
@@ -66,13 +66,11 @@ function AssignmentPlanning (props) {
     />
   )
 
-  const tableBuilder = (loaded, assignmentData, table) => {
+  const tableBuilder = (assignmentData) => {
     if (!assignmentData || Object.keys(assignmentData).length === 0) {
       return (<p>No data provided</p>)
-    } else if (loaded) {
-      return AssignmentTable(assignmentData.plan)
-    } 
-    return <Spinner />
+    }
+    return AssignmentTable(assignmentData)
   }
 
   return (
@@ -97,7 +95,7 @@ function AssignmentPlanning (props) {
                   <MenuItem value={75}>75%</MenuItem>
                 </Select>
               </FormControl>
-              { tableBuilder(loaded, assignmentData) }
+              {loaded ? tableBuilder(assignmentData.plan) : <Spinner />}
             </>
           </Paper>
         </Grid>

--- a/assets/src/containers/AssignmentPlanning.js
+++ b/assets/src/containers/AssignmentPlanning.js
@@ -66,6 +66,15 @@ function AssignmentPlanning (props) {
     />
   )
 
+  const tableBuilder = (loaded, assignmentData, table) => {
+    if (!assignmentData || Object.keys(assignmentData).length === 0) {
+      return (<p>No data provided</p>)
+    } else if (loaded) {
+      return AssignmentTable(assignmentData.plan)
+    } 
+    return <Spinner />
+  }
+
   return (
     <div className={classes.root}>
       <Grid container spacing={16}>
@@ -88,7 +97,7 @@ function AssignmentPlanning (props) {
                   <MenuItem value={75}>75%</MenuItem>
                 </Select>
               </FormControl>
-              {loaded ? AssignmentTable(assignmentData.plan) : <Spinner />}
+              { tableBuilder(loaded, assignmentData) }
             </>
           </Paper>
         </Grid>

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -30,37 +30,35 @@ function GradeDistribution (props) {
   const currentCourseId = match.params.courseId
   const [loaded, gradeData] = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/grade_distribution`)
 
-  const tableBuilder = (loaded, assignmentData, table) => {
+  const tableBuilder = (gradeData) => {
     if (!gradeData || Object.keys(gradeData).length === 0) {
       return (<p>No data provided</p>)
-    } else if (loaded) {
-      return (
-        <>
-          <Grid item xs={12} sm={4} lg={2}>
-            <Table className={classes.table} tableData={[
-              ['Number of Students', <strong>{gradeData.length}</strong>],
-              ['Average Grade', <strong>{average(gradeData.map(x => x.current_grade))}%</strong>],
-              ['My Grade', <strong>{gradeData[0].current_user_grade}%</strong>]
-            ]} />
-          </Grid>
-          <Histogram
-            data={gradeData.map(x => x.current_grade)}
-            tip={createToolTip(d => renderToString(
-              <Paper className={classes.paper}>
-                <Table className={classes.table} tableData={[
-                  ['Number of Students', <strong>{d.length}</strong>],
-                  ['Average Grade', <strong>{average(d)}%</strong>]
-                ]} />
-              </Paper>
-            ))}
-            aspectRatio={0.3}
-            xAxisLabel={'Grade %'}
-            yAxisLabel={'Number of Students'}
-            myGrade={gradeData[0].current_user_grade} />
-        </>
-      )
     } 
-    return <Spinner />
+    return (
+      <>
+        <Grid item xs={12} sm={4} lg={2}>
+          <Table className={classes.table} tableData={[
+            ['Number of Students', <strong>{gradeData.length}</strong>],
+            ['Average Grade', <strong>{average(gradeData.map(x => x.current_grade))}%</strong>],
+            ['My Grade', <strong>{gradeData[0].current_user_grade}%</strong>]
+          ]} />
+        </Grid>
+        <Histogram
+          data={gradeData.map(x => x.current_grade)}
+          tip={createToolTip(d => renderToString(
+            <Paper className={classes.paper}>
+              <Table className={classes.table} tableData={[
+                ['Number of Students', <strong>{d.length}</strong>],
+                ['Average Grade', <strong>{average(d)}%</strong>]
+              ]} />
+            </Paper>
+          ))}
+          aspectRatio={0.3}
+          xAxisLabel={'Grade %'}
+          yAxisLabel={'Number of Students'}
+          myGrade={gradeData[0].current_user_grade} />
+      </>
+    )
   }
 
   return (
@@ -69,7 +67,7 @@ function GradeDistribution (props) {
         <Grid item xs={12}>
           <Paper className={classes.paper}>
             <Typography variant='h5' gutterBottom >Grade Distribution</Typography >
-             { tableBuilder(loaded, gradeData) }
+             {loaded ? tableBuilder(gradeData) : <Spinner />}
           </Paper>
         </Grid>
       </Grid>

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -29,36 +29,47 @@ function GradeDistribution (props) {
   const { classes, match } = props
   const currentCourseId = match.params.courseId
   const [loaded, gradeData] = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/grade_distribution`)
+
+  const tableBuilder = (loaded, assignmentData, table) => {
+    if (!gradeData || Object.keys(gradeData).length === 0) {
+      return (<p>No data provided</p>)
+    } else if (loaded) {
+      return (
+        <>
+          <Grid item xs={12} sm={4} lg={2}>
+            <Table className={classes.table} tableData={[
+              ['Number of Students', <strong>{gradeData.length}</strong>],
+              ['Average Grade', <strong>{average(gradeData.map(x => x.current_grade))}%</strong>],
+              ['My Grade', <strong>{gradeData[0].current_user_grade}%</strong>]
+            ]} />
+          </Grid>
+          <Histogram
+            data={gradeData.map(x => x.current_grade)}
+            tip={createToolTip(d => renderToString(
+              <Paper className={classes.paper}>
+                <Table className={classes.table} tableData={[
+                  ['Number of Students', <strong>{d.length}</strong>],
+                  ['Average Grade', <strong>{average(d)}%</strong>]
+                ]} />
+              </Paper>
+            ))}
+            aspectRatio={0.3}
+            xAxisLabel={'Grade %'}
+            yAxisLabel={'Number of Students'}
+            myGrade={gradeData[0].current_user_grade} />
+        </>
+      )
+    } 
+    return <Spinner />
+  }
+
   return (
     <div className={classes.root}>
       <Grid container spacing={16}>
         <Grid item xs={12}>
           <Paper className={classes.paper}>
             <Typography variant='h5' gutterBottom >Grade Distribution</Typography >
-            {loaded
-              ? <>
-                <Grid item xs={12} sm={4} lg={2}>
-                  <Table className={classes.table} tableData={[
-                    ['Number of Students', <strong>{gradeData.length}</strong>],
-                    ['Average Grade', <strong>{average(gradeData.map(x => x.current_grade))}%</strong>],
-                    ['My Grade', <strong>{gradeData[0].current_user_grade}%</strong>]
-                  ]} />
-                </Grid>
-                <Histogram
-                  data={gradeData.map(x => x.current_grade)}
-                  tip={createToolTip(d => renderToString(
-                    <Paper className={classes.paper}>
-                      <Table className={classes.table} tableData={[
-                        ['Number of Students', <strong>{d.length}</strong>],
-                        ['Average Grade', <strong>{average(d)}%</strong>]
-                      ]} />
-                    </Paper>
-                  ))}
-                  aspectRatio={0.3}
-                  xAxisLabel={'Grade %'}
-                  yAxisLabel={'Number of Students'}
-                  myGrade={gradeData[0].current_user_grade} />
-              </> : <Spinner />}
+             { tableBuilder(loaded, gradeData) }
           </Paper>
         </Grid>
       </Grid>


### PR DESCRIPTION
The `GradeDistribution` page and `AssignmentPlanning` page shows error when `gradeData` or `assignmentData` is an empty object.  