### PR TITLE
Abstract api calls into api folder to allow for testing with mock calls

### DIFF
--- a/assets/src/containers/AssignmentPlanning.js
+++ b/assets/src/containers/AssignmentPlanning.js
@@ -10,7 +10,7 @@ import InputLabel from '@material-ui/core/InputLabel'
 import MenuItem from '@material-ui/core/MenuItem'
 import Table from '../components/Table'
 import HorizontalBar from '../components/HorizontalBar'
-import useAssignmentPlanningData from '../../src/service/api'
+import { useAssignmentPlanningData } from '../service/api'
 
 const styles = theme => ({
   root: {
@@ -27,7 +27,7 @@ function AssignmentPlanning (props) {
   const { classes, match } = props
   const currentCourseId = match.params.courseId
   const [assignmentFilter, setAssignmentFilter] = useState(0)
-  const [loaded, assignmentData] = useAssignmentPlanningData
+  const [loaded, assignmentData] = useAssignmentPlanningData(currentCourseId, assignmentFilter)
 
   const generateAssignmentTable = plan => {
     const tableArray = plan.reduce((acc, weekItem) => {

--- a/assets/src/containers/AssignmentPlanning.js
+++ b/assets/src/containers/AssignmentPlanning.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import useFetch from '../hooks/useFetch'
 import { withStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
 import Grid from '@material-ui/core/Grid'
@@ -11,6 +10,7 @@ import InputLabel from '@material-ui/core/InputLabel'
 import MenuItem from '@material-ui/core/MenuItem'
 import Table from '../components/Table'
 import HorizontalBar from '../components/HorizontalBar'
+import useAssignmentPlanningData from '../../src/service/api'
 
 const styles = theme => ({
   root: {
@@ -27,7 +27,7 @@ function AssignmentPlanning (props) {
   const { classes, match } = props
   const currentCourseId = match.params.courseId
   const [assignmentFilter, setAssignmentFilter] = useState(0)
-  const [loaded, assignmentData] = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=${assignmentFilter}`)
+  const [loaded, assignmentData] = useAssignmentPlanningData
 
   const generateAssignmentTable = plan => {
     const tableArray = plan.reduce((acc, weekItem) => {

--- a/assets/src/containers/FilesAccessed.js
+++ b/assets/src/containers/FilesAccessed.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import useFetch from '../hooks/useFetch'
 import { withStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
 import Spinner from '../components/Spinner'
+import useFilesAccessedAssignmentData from '../../src/service/api'
 
 const styles = theme => ({
   root: {
@@ -20,7 +20,7 @@ const styles = theme => ({
 function FilesAccessed (props) {
   const { classes, match } = props
   const currentCourseId = match.params.courseId
-  const [loaded, assignmentData] = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=0`)
+  const [loaded, assignmentData] = useFilesAccessedAssignmentData
   return (
     <div className={classes.root}>
       <Grid container spacing={16}>

--- a/assets/src/containers/FilesAccessed.js
+++ b/assets/src/containers/FilesAccessed.js
@@ -4,7 +4,7 @@ import Paper from '@material-ui/core/Paper'
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
 import Spinner from '../components/Spinner'
-import useFilesAccessedAssignmentData from '../../src/service/api'
+import { useFilesAccessedAssignmentData } from '../service/api'
 
 const styles = theme => ({
   root: {
@@ -20,7 +20,7 @@ const styles = theme => ({
 function FilesAccessed (props) {
   const { classes, match } = props
   const currentCourseId = match.params.courseId
-  const [loaded, assignmentData] = useFilesAccessedAssignmentData
+  const [loaded, assignmentData] = useFilesAccessedAssignmentData(currentCourseId)
   return (
     <div className={classes.root}>
       <Grid container spacing={16}>

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { renderToString } from 'react-dom/server'
-import useFetch from '../hooks/useFetch'
 import { withStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
 import Grid from '@material-ui/core/Grid'
@@ -10,6 +9,7 @@ import Spinner from '../components/Spinner'
 import createToolTip from '../util/createToolTip'
 import Table from '../components/Table'
 import { average } from '../util/math'
+import useGradeData from '../../src/service/api'
 
 const styles = theme => ({
   root: {
@@ -28,12 +28,12 @@ const styles = theme => ({
 function GradeDistribution (props) {
   const { classes, match } = props
   const currentCourseId = match.params.courseId
-  const [loaded, gradeData] = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/grade_distribution`)
+  const [loaded, gradeData] = useGradeData
 
   const tableBuilder = (gradeData) => {
     if (!gradeData || Object.keys(gradeData).length === 0) {
       return (<p>No data provided</p>)
-    } 
+    }
     return (
       <>
         <Grid item xs={12} sm={4} lg={2}>

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -9,7 +9,7 @@ import Spinner from '../components/Spinner'
 import createToolTip from '../util/createToolTip'
 import Table from '../components/Table'
 import { average } from '../util/math'
-import useGradeData from '../../src/service/api'
+import { useGradeData } from '../service/api'
 
 const styles = theme => ({
   root: {
@@ -28,7 +28,7 @@ const styles = theme => ({
 function GradeDistribution (props) {
   const { classes, match } = props
   const currentCourseId = match.params.courseId
-  const [loaded, gradeData] = useGradeData
+  const [loaded, gradeData] = useGradeData(currentCourseId)
 
   const tableBuilder = (gradeData) => {
     if (!gradeData || Object.keys(gradeData).length === 0) {

--- a/assets/src/hooks/useFetch.js
+++ b/assets/src/hooks/useFetch.js
@@ -1,7 +1,12 @@
+/* global fetch */
 import { useState, useEffect } from 'react'
-import get from '../service/api'
 
 const cache = new Map()
+
+const get = url => {
+  return fetch(url)
+    .then(res => res.json())
+}
 
 const useFetch = dataURL => {
   const [data, setData] = useState(null)

--- a/assets/src/service/api.js
+++ b/assets/src/service/api.js
@@ -1,8 +1,5 @@
-/* global fetch */
+import useFetch from '../hooks/useFetch'
 
-const get = url => {
-  return fetch(url)
-    .then(res => res.json())
-}
-
-export default get
+export const useGradeData = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/grade_distribution`)
+export const useAssignmentPlanningData = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=${assignmentFilter}`)
+export const useFilesAccessedAssignmentData = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=0`)

--- a/assets/src/service/api.js
+++ b/assets/src/service/api.js
@@ -1,5 +1,5 @@
 import useFetch from '../hooks/useFetch'
 
-export const useGradeData = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/grade_distribution`)
-export const useAssignmentPlanningData = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=${assignmentFilter}`)
-export const useFilesAccessedAssignmentData = useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=0`)
+export const useGradeData = (currentCourseId) => useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/grade_distribution`)
+export const useAssignmentPlanningData = (currentCourseId, assignmentFilter) => useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=${assignmentFilter}`)
+export const useFilesAccessedAssignmentData = (currentCourseId) => useFetch(`http://localhost:5001/api/v1/courses/${currentCourseId}/assignments?percent=0`)


### PR DESCRIPTION
In order to use mock objects for testing purposes, I had to abstract current API calls into separate functions. This will lead to a separate PR, which will use mock API calls (that will be stored with fake data in a `__mock__` folder) to test for react containers. 