### PR TITLE
Expanded useFetch to support 'put', 'post', etc.

### DIFF
--- a/assets/src/hooks/useFetch.js
+++ b/assets/src/hooks/useFetch.js
@@ -2,33 +2,46 @@
 import { useState, useEffect } from 'react'
 
 const cache = new Map()
-// https://sudo.isl.co/fetch-me-that-json-from-django/
-const get = url => {
-  return fetch(url,{
-    headers: {
-      'Accept': 'application/json',
-      'X-Requested-With': 'XMLHttpRequest'
-    },
-    credentials: 'include'
-  })
-    .then(res => res.json())
+
+const defaultFetchOptions = {
+  headers: {
+    'Accept': 'application/json',
+    'X-Requested-With': 'XMLHttpRequest'
+  },
+  credentials: 'include'
 }
 
-const useFetch = dataURL => {
+const useFetch = (dataURL, options) => {
+  const fetchOptions = options
+    ? { ...options, ...defaultFetchOptions }
+    : { method: 'get', ...defaultFetchOptions }
+
   const [data, setData] = useState(null)
   const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
-    if (cache.has(dataURL)) {
-      setData(cache.get(dataURL))
-      setLoaded(true)
-    } else {
-      setLoaded(false)
-      get(dataURL).then(data => {
-        cache.set(dataURL, data)
-        setData(data)
+    if (fetchOptions.method === 'get') {
+      // only cache 'get' calls
+      if (cache.has(dataURL)) {
+        setData(cache.get(dataURL))
         setLoaded(true)
-      })
+      } else {
+        setLoaded(false)
+        fetch(dataURL, fetchOptions)
+          .then(res => res.json())
+          .then(data => {
+            cache.set(dataURL, data)
+            setData(data)
+            setLoaded(true)
+          })
+      }
+    } else {
+      fetch(dataURL, fetchOptions)
+        .then(res => res.json())
+        .then(data => {
+          setData(data)
+          setLoaded(true)
+        })
     }
   }, [dataURL])
 


### PR DESCRIPTION
Addresses https://github.com/tl-its-umich-edu/my-learning-analytics/issues/475.

`GET` is set by default, and the second parameter to `useFetch` can be used to pass `body` and `method` options to the [fetch api](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch).  