### PR TITLE
Added equivalent hooks to HOCs

### DIFF
--- a/assets/src/components/Histogram.js
+++ b/assets/src/components/Histogram.js
@@ -1,11 +1,17 @@
+import React, { useState } from 'react'
 import createHistogram from './d3/createHistogram'
-import withResponsiveness from './withResponsiveness'
-import createChartComponent from './createChartComponent'
-import compose from '../util/compose'
+import useChart from '../hooks/useChart'
+import useResponsiveness from '../hooks/useResponsiveness'
 
-const Histogram = compose(
-  withResponsiveness,
-  createChartComponent
-)(createHistogram)
+function Histogram (props) {
+  const [el, setEl] = useState(null)
+
+  const [width, height] = useResponsiveness({ ...props, el })
+  useChart({ ...props, el, width, height }, createHistogram)
+
+  return (
+    <div ref={el => setEl(el)} />
+  )
+}
 
 export default Histogram

--- a/assets/src/components/Histogram.js
+++ b/assets/src/components/Histogram.js
@@ -7,7 +7,7 @@ function Histogram (props) {
   const [el, setEl] = useState(null)
 
   const [width, height] = useResponsiveness({ ...props, el })
-  useChart({ ...props, el, width, height }, createHistogram)
+  useCreateChart({ ...props, el, width, height }, createHistogram)
 
   return (
     <div ref={el => setEl(el)} />

--- a/assets/src/components/Histogram.js
+++ b/assets/src/components/Histogram.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import createHistogram from './d3/createHistogram'
-import useChart from '../hooks/useChart'
+import useCreateChart from '../hooks/useCreateChart'
 import useResponsiveness from '../hooks/useResponsiveness'
 
 function Histogram (props) {

--- a/assets/src/components/Histogram.js
+++ b/assets/src/components/Histogram.js
@@ -4,13 +4,13 @@ import useCreateChart from '../hooks/useCreateChart'
 import useResponsiveness from '../hooks/useResponsiveness'
 
 function Histogram (props) {
-  const [el, setEl] = useState(null)
+  const [domElement, setDomElement] = useState(null)
 
-  const [width, height] = useResponsiveness({ ...props, el })
-  useCreateChart({ ...props, el, width, height }, createHistogram)
+  const [width, height] = useResponsiveness({ ...props, domElement })
+  useCreateChart({ ...props, domElement, width, height }, createHistogram)
 
   return (
-    <div ref={el => setEl(el)} />
+    <div ref={domElement => setDomElement(domElement)} />
   )
 }
 

--- a/assets/src/components/createChartComponent.js
+++ b/assets/src/components/createChartComponent.js
@@ -3,7 +3,7 @@ import { destroyChart } from '../util/chart'
 
 const createChartComponent = chart => memo(props => {
   const { data } = props
-  const [el, setEl] = useState(null)
+  const [domElement, setDomElement] = useState(null)
 
   useEffect(() => {
     if (el && data) {
@@ -13,7 +13,7 @@ const createChartComponent = chart => memo(props => {
   })
 
   return (
-    <div ref={el => setEl(el)} />
+    <div ref={domElement => setDomElement(domElement)} />
   )
 })
 

--- a/assets/src/components/withResponsiveness.js
+++ b/assets/src/components/withResponsiveness.js
@@ -4,28 +4,28 @@ import { createResize } from '../util/chart'
 const withResponsiveness = ChartComponent => props => {
   const { aspectRatio = 0.75 } = props
   const minimumWidth = 400
-  const [el, setEl] = useState(null)
+  const [domElement, setDomElement] = useState(null)
   const [width, setWidth] = useState(null)
 
-  const setContainer = el => {
-    if (el) {
-      setEl(el)
-      setWidth(el.getBoundingClientRect().width > minimumWidth
-        ? el.getBoundingClientRect().width
+  const setContainer = domElement => {
+    if (domElement) {
+      setDomElement(domElement)
+      setWidth(domElement.getBoundingClientRect().width > minimumWidth
+        ? domElement.getBoundingClientRect().width
         : minimumWidth)
     }
   }
 
   useEffect(() => {
     const optimizedResize = createResize()
-    optimizedResize.add(() => setContainer(el))
+    optimizedResize.add(() => setContainer(domElement))
     return optimizedResize.remove
   })
 
   const notNull = (width !== null)
 
   return (
-    <div ref={el => setContainer(el)}>
+    <div ref={domElement => setContainer(domElement)}>
       {notNull && <ChartComponent width={width} height={width * aspectRatio} {...props} /> }
     </div>
   )

--- a/assets/src/hooks/useCreateChart.js
+++ b/assets/src/hooks/useCreateChart.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { destroyChart } from '../util/chart'
+
+const useCreateChart = (props, chart) => {
+  const { el, data, width } = props
+
+  useEffect(() => {
+    if (el && data && width) {
+      chart({ ...props, el, data })
+      return () => destroyChart(el)
+    }
+  })
+}
+
+export default useCreateChart

--- a/assets/src/hooks/useResponsiveness.js
+++ b/assets/src/hooks/useResponsiveness.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import { createResize } from '../util/chart'
+
+const useResponsiveness = props => {
+  const { el, aspectRatio = 0.75 } = props
+  const [width, setWidth] = useState(null)
+
+  const setContainer = () => {
+    if (el) {
+      setWidth(el.getBoundingClientRect().width)
+    }
+  }
+
+  useEffect(() => {
+    setContainer()
+    const optimizedResize = createResize()
+    optimizedResize.add(() => setContainer())
+    return optimizedResize.remove
+  })
+
+  return [width, width * aspectRatio]
+}
+
+export default useResponsiveness


### PR DESCRIPTION
Here's an example of converting higher-order components (HOCs) to hooks. I think it's easier to understand, and it also doesn't cause unnecessary component nesting (since each HOC component adds a new layer of nesting). 

Let me know what you think! 

Happy to rewrite the rest of the React D3 components so they use hooks instead of HOCs. 