### PR TITLE
Changed Copyright footer so it is not hard coded for one institution

### DIFF
--- a/assets/src/containers/FilesAccessed.js
+++ b/assets/src/containers/FilesAccessed.js
@@ -47,6 +47,7 @@ function FilesAccessed (props) {
   const [curWeek, setCurWeek] = useState(0) // Should be updated from info
   const [weekRange, setWeekRange] = useState([]) // Should be depend on curWeek
   const [gradeRangeFilter, setGradeRangeFilter] = useState('') // Should be fetched from default
+  const [fileFilter, setFileFilter] = useState('');
   const [fileAccessData, setFileAccessData] = useState('')
   const [dataControllerLoad, setDataControllerLoad] = useState(0)
   // initial default value that we get from backend and updated value when user save the default setting
@@ -55,6 +56,9 @@ function FilesAccessed (props) {
   // defaults setting controllers
   const [defaultCheckboxState, setDefaultCheckedState] = useState(true)
   const [defaultLabel, setDefaultLabel] = useState(currentSetting)
+
+  const canvas_file = myla_globals.canvas_file
+  const leccap_file = myla_globals.leccap_file
 
   const changeDefaultSetting = (event) => {
     const didUserChecked = event.target.checked
@@ -115,10 +119,12 @@ function FilesAccessed (props) {
     if (loaded) {
       if (filesDefaultData.default !== '') {
         setGradeRangeFilter(filesDefaultData.default)
+        setFileFilter(filesDefaultData.default)
         setDefaultValue(filesDefaultData.default)
       } else {
         // setting it to default
         setGradeRangeFilter('All')
+        setFileFilter('all_files')
         setDefaultValue('All')
       }
       setDataControllerLoad(dataControllerLoad + 1)
@@ -128,7 +134,7 @@ function FilesAccessed (props) {
   useEffect(() => {
     // Fetch data once all the setting data is fetched
     if (dataControllerLoad === 2) {
-      const dataURL = `/api/v1/courses/${courseId}/file_access_within_week?week_num_start=${weekRange[0]}&week_num_end=${weekRange[1]}&grade=${gradeRangeFilter}`
+      const dataURL = `/api/v1/courses/${courseId}/file_access_within_week?week_num_start=${weekRange[0]}&week_num_end=${weekRange[1]}&grade=${gradeRangeFilter}&file_type=${fileFilter}`
       fetch(dataURL)
         .then(handleError)
         .then(res => res.json())
@@ -139,7 +145,7 @@ function FilesAccessed (props) {
           setFileAccessData({})
         })
     }
-  }, [dataControllerLoad, weekRange, gradeRangeFilter])
+  }, [dataControllerLoad, weekRange, gradeRangeFilter, fileFilter])
 
   const onWeekChangeHandler = value => {
     // Update week range slider
@@ -157,6 +163,11 @@ function FilesAccessed (props) {
       setDefaultCheckedState(false)
       setDefaultLabel(rememberSetting)
     }
+  }
+
+  const onChangeFileHandler = event => {
+    const value = event.target.value
+    setFileFilter(value)
   }
 
   const FileAccessChartBuilder = (fileData) => {
@@ -189,9 +200,23 @@ function FilesAccessed (props) {
               onWeekChange={onWeekChangeHandler}
             /> : ''}
             <div className={classes.formController}>
-              <p>File accessed from
+              <FormControl className={classes.formControl}>
+                <Select
+                  value={fileFilter}
+                  onChange={onChangeFileHandler}
+                  inputProps={{
+                    name: 'file',
+                    id: 'file-type',
+                  }}
+                >
+                  <MenuItem value="all_files">All</MenuItem>
+                  <MenuItem value={canvas_file}>Canvas</MenuItem>
+                  <MenuItem value={leccap_file}>Lecture Capture</MenuItem>
+                </Select>
+              </FormControl>
+              <p>Files accessed from
                 week <b>{weekRange[0]} {weekRange[0] === curWeek ? ' (Now)' : ''}</b> to <b>{weekRange[1]}{weekRange[1] === curWeek ? ' (Now)' : ''}</b> with
-                these grades:</p>
+                these grades: </p>
               <FormControl className={classes.formControl}>
                 <Select
                   value={gradeRangeFilter}
@@ -202,9 +227,9 @@ function FilesAccessed (props) {
                   }}
                 >
                   <MenuItem value="All">All</MenuItem>
-                  <MenuItem value="90-100">90-100%</MenuItem>
-                  <MenuItem value="80-89">80-89%</MenuItem>
-                  <MenuItem value="70-79">70-79%</MenuItem>
+                  <MenuItem value="90-100"> 90-100%</MenuItem>
+                  <MenuItem value="80-89"> 80-89%</MenuItem>
+                  <MenuItem value="70-79"> 70-79%</MenuItem>
                 </Select>
               </FormControl>
               {defaultCheckboxState ? <div style={{ padding: '10px' }}></div> : <Checkbox

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -12,3 +12,10 @@ def get_build_info():
     build_name=config("OPENSHIFT_BUILD_NAME",default="")
     return f'Build_Namespace:{build_namespace} Build_Name: {build_name} Git_Source: {build_source} Git_Branch: {git_branch} Git_Commit: {git_commit}'
 
+def get_copyright_info():
+    institutions={"umich": "The Regents of the University of Michigan", "iu": "The Trustees of Indiana University", "ubc": "UBC"}
+    institution=config("INSTITUTION",default="")
+    copyright_str="Copyright &copy "
+    year=datetime.now().year
+    copyright_str+=str(year)+institutions[institution]
+    return f'Copyright © {year} {institutions[institution]}'

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -1,5 +1,6 @@
 import logging
 from decouple import config
+from datetime import datetime
 logger = logging.getLogger(__name__)
 
 
@@ -14,8 +15,7 @@ def get_build_info():
 
 def get_copyright_info():
     institutions={"umich": "The Regents of the University of Michigan", "iu": "The Trustees of Indiana University", "ubc": "UBC"}
-    institution=config("INSTITUTION",default="")
-    copyright_str="Copyright &copy "
+    institution=config("INSTITUTION",default="umich")
     year=datetime.now().year
-    copyright_str+=str(year)+institutions[institution]
-    return f'Copyright © {year} {institutions[institution]}'
+    copyright_str=institutions[institution]
+    return f'Copyright © {year} {copyright_str}'

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -17,6 +17,8 @@ from decouple import config, Csv
 
 from debug_toolbar import settings as dt_settings
 
+from dashboard.common import utils
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -31,6 +33,9 @@ LOGIN_URL = '/accounts/login'
 
 # Google Analytics ID
 GA_ID = config('GA_ID', default='')
+
+# Copyright Information
+COPYRIGHT = utils.get_copyright_info()
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
@@ -382,7 +387,7 @@ BIG_QUERY_ED_APP = config('BIG_QUERY_ED_APP', default="http://umich.instructure.
 RUN_AT_TIMES = config('RUN_AT_TIMES', default="", cast= Csv())
 
 # Add any settings you need to be available to templates in this array
-SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID']
+SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID', 'COPYRIGHT']
 
 # Method to show the user, if they're authenticated and superuser
 def show_debug_toolbar(request):

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -37,6 +37,10 @@ GA_ID = config('GA_ID', default='')
 # Copyright Information
 COPYRIGHT = utils.get_copyright_info()
 
+# File values from .env
+CANVAS_FILE = config('CANVAS_FILE', default='0')
+LECCAP_FILE = config('LECCAP_FILE', default='1')
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
@@ -387,7 +391,7 @@ BIG_QUERY_ED_APP = config('BIG_QUERY_ED_APP', default="http://umich.instructure.
 RUN_AT_TIMES = config('RUN_AT_TIMES', default="", cast= Csv())
 
 # Add any settings you need to be available to templates in this array
-SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID', 'COPYRIGHT']
+SETTINGS_EXPORT = ['LOGIN_URL','LOGOUT_URL','DEBUG', 'GA_ID', 'COPYRIGHT', 'CANVAS_FILE', 'LECCAP_FILE']
 
 # Method to show the user, if they're authenticated and superuser
 def show_debug_toolbar(request):

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -47,6 +47,16 @@
         {% else %}
             "user_courses_info":"",
         {% endif %}
+        {% if settings.CANVAS_FILE %}
+            "canvas_file": '{{ settings.CANVAS_FILE }}',
+        {% else %}
+            "canvas_file":"0",
+        {% endif %}
+        {% if settings.LECCAP_FILE %}
+            "leccap_file": '{{ settings.LECCAP_FILE }}',
+        {% else %}
+            "leccap_file":"1",
+        {% endif %}
 
         }
     </script>

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -57,7 +57,7 @@
     {% endblock %}
     {% csrf_token %}
     <footer>
-        <div style="float: left; width: 50%">Copyright © 2018 The Regents of the University of Michigan</div>
+        <div style="float: left; width: 50%">{{settings.COPYRIGHT}}</div>
         <div style="float: left; width: 50%; text-align: right">Data last updated on {{last_updated|date:"m/d/Y P T"}}</div>
         {% if user.is_superuser %}
         <div id="build-info" class="alert alert-info" style="display:none;">{{build}}</div>


### PR DESCRIPTION
Modified `utils.py`, `settings.py`, and `base.html` to have a copyright footer that is not hardcoded for UofM. `.env` has a new variable `INSTITUTION` which can be set to an institution's acronyms like umich, iu, or ubc which will determine which footer to show. This fixes #523. 