### PR TITLE
Adding copyright text using django flatpages

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ This will remove everything! (images, containers, volumes)
 
 *Docker stores MySQL data locally in the directory `.data`. If you want to fully clean you'll have to remove this folder.*
 
+## Populating Copyright information in footer
+1. Since MyLA can be used by multiple institution, copyright information needs to be entitled to institutions needs. 
+2. Django Flatpages serves the purpose. The display of the copyright content can be controlled from the Django Admin view. 
+3. The url for configuring copyright info must be `/copyright/` since that is used in the `base.html` for pulling the info
+[More info](https://simpleisbetterthancomplex.com/tutorial/2016/10/04/how-to-use-django-flatpages-app.html)
+
 ## Testing tips!
 
 1. Connect to the docker and edit some files!

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -31,6 +31,8 @@ LOGIN_URL = '/accounts/login'
 
 # Google Analytics ID
 GA_ID = config('GA_ID', default='')
+
+# This is required by flatpages flow. For Example Copyright information in the footer populated from flatpages
 SITE_ID = 1
 
 # Quick-start development settings - unsuitable for production

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -31,6 +31,7 @@ LOGIN_URL = '/accounts/login'
 
 # Google Analytics ID
 GA_ID = config('GA_ID', default='')
+SITE_ID = 1
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
@@ -67,6 +68,8 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.sites',
+    'django.contrib.flatpages',
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'django_cron',

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -57,7 +57,13 @@
     {% endblock %}
     {% csrf_token %}
     <footer>
-        <div style="float: left; width: 50%">Copyright © 2018 The Regents of the University of Michigan</div>
+        {% load flatpages %}
+        {% get_flatpages as flatpages %}
+        {% for page in flatpages %}
+        {% if page.url == '/copyright/'%}
+        <div style="float: left; width: 50%">{{ page.content }}</div>
+        {% endif %}
+        {% endfor %}
         <div style="float: left; width: 50%; text-align: right">Data last updated on {{last_updated|date:"m/d/Y P T"}}</div>
         {% if user.is_superuser %}
         <div id="build-info" class="alert alert-info" style="display:none;">{{build}}</div>

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -58,13 +58,11 @@
     {% csrf_token %}
     <footer>
         {% load flatpages %}
-        {% get_flatpages as flatpages %}
-        {% for page in flatpages %}
-        {% if page.url == '/copyright/'%}
-        <div style="float: left; width: 50%">{{ page.content }}</div>
-        {% endif %}
-        {% endfor %}
+        {% get_flatpages '/copyright/' as flatpages %}
+        <div>
+        <div style="float: left; width: 50%">{{ flatpages.first.content|safe }}</div>
         <div style="float: left; width: 50%; text-align: right">Data last updated on {{last_updated|date:"m/d/Y P T"}}</div>
+        </div>
         {% if user.is_superuser %}
         <div id="build-info" class="alert alert-info" style="display:none;">{{build}}</div>
         {% endif %}


### PR DESCRIPTION
solves #523 
- This PR solves the issue of adding Copyright information in the footer using Django [flatpages](https://docs.djangoproject.com/en/1.11/ref/contrib/flatpages/) from Django admin view.
- The requisite seems to agree on a flatpage url currently I have it as `copyright`
- Django Flatpages can provision creating static pages like `/about/` but I took the approach of getting the flatpage content to be populated inside of the template. More info [here](https://docs.djangoproject.com/en/1.11/ref/contrib/flatpages/#getting-a-list-of-flatpage-objects-in-your-templates)
- Currently, I have the instance of this code running on https://dev-myla.tl.it.umich.edu/ for review process. 