### PR TITLE
Correctly route to index page when app bar name is clicked

### DIFF
--- a/assets/src/containers/DashboardAppBar.js
+++ b/assets/src/containers/DashboardAppBar.js
@@ -64,7 +64,7 @@ function DashboardAppBar (props) {
           <Button>
             <Typography variant='h6' color='inherit' className={classes.grow}>
               <Link
-                to={{ pathname: `/${courseId}` }}
+                to={{ pathname: `/courses/${courseId}` }}
                 className={classes.homeButton}>
                   My Learning Analytics: {courseName}
               </Link>


### PR DESCRIPTION
When `My Learning Analytics: {Course Name}` is clicked, it routes to `localhost:5001/{course code}` instead of `localhost:5001/courses/{course code}`. This PR resolves this issue.