### PR TITLE
Updated dependencies, resolved security warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "dependencies": {
     "bootstrap": "~4.3.1",
-    "d3": "~5.9.1",
+    "d3": "^5.9.4",
     "d3-tip": "~0.9.1",
     "jquery": ">=3.4.0",
-    "rc-slider": "^8.6.7"
+    "rc-slider": "^8.6.13"
   },
   "babel": {
     "presets": [
@@ -69,19 +69,21 @@
       "jsx",
       "node"
     ],
-    "testPathIgnorePatterns": ["testData"]
+    "testPathIgnorePatterns": [
+      "testData"
+    ]
   },
   "devDependencies": {
     "@babel/core": "~7.3.4",
-    "@material-ui/core": "~3.9.2",
+    "@material-ui/core": "^3.9.3",
     "@material-ui/icons": "~3.0.2",
-    "@svgr/webpack": "~4.1.0",
-    "@webpack-cli/init": "~0.1.3",
+    "@svgr/webpack": "^4.3.0",
+    "@webpack-cli/init": "^0.2.2",
     "babel-cli": "~6.26.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
-    "babel-loader": "~8.0.5",
-    "babel-plugin-named-asset-import": "~0.3.1",
+    "babel-loader": "^8.0.6",
+    "babel-plugin-named-asset-import": "^0.3.2",
     "babel-preset-env": "~1.7.0",
     "babel-preset-react-app": "~7.0.2",
     "babel-register": "~6.26.0",
@@ -90,12 +92,12 @@
     "css-loader": "~2.1.1",
     "eslint": "5.15.1",
     "eslint-config-react-app": "~3.0.8",
+    "eslint-config-standard": "^12.0.0",
     "eslint-loader": "2.1.2",
     "eslint-plugin-flowtype": "3.4.2",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-react": "7.12.4",
-    "eslint-config-standard": "^12.0.0",
     "extract-text-webpack-plugin": "~3.0.2",
     "file-loader": "3.0.1",
     "fork-ts-checker-webpack-plugin-alt": "0.4.14",
@@ -115,12 +117,12 @@
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.6.0",
     "postcss-safe-parser": "4.0.1",
-    "react": "~16.8.4",
+    "react": "^16.8.6",
     "react-app-polyfill": "~0.2.2",
     "react-dev-utils": "~8.0.0",
-    "react-dom": "~16.8.4",
-    "react-router-dom": "~4.3.1",
+    "react-dom": "^16.8.6",
     "react-ga": "~2.5.7",
+    "react-router-dom": "~4.3.1",
     "resolve": "1.10.0",
     "sass-loader": "~7.1.0",
     "style-loader": "~0.23.1",


### PR DESCRIPTION
The Node Package Manager (NPM) warned of security warnings during the build phase of docker, so I updated the dependencies, which got rid of nearly all the warnings (and all of the high and medium level vulnerabilities). 

To test, please rebuild your docker: `docker-compose up -d --build`.

I tested and everything seemed to be working as normal. 