### PR TITLE
Fixes #589 switch wait-port over to netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN npm run prod && \
 # build node libraries for production mode
 FROM node-webpack AS node-prod-deps
 
-RUN npm install --save wait-port@"~0.2.2" && \
-    npm prune --production && \
+RUN npm prune --production && \
     # This is needed to clean up the examples files as these cause collectstatic to fail (and take up extra space)
     find /usr/src/app/node_modules -type d -name "examples" -print0 | xargs -0 rm -rf
 
@@ -33,7 +32,7 @@ WORKDIR /code
 # NOTE: requirements.txt not likely to change between dev builds
 COPY requirements.txt /code/requirements.txt
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends vim-tiny jq python3-dev xmlsec1 cron && \
+    apt-get install -y --no-install-recommends netcat vim-tiny jq python3-dev xmlsec1 cron && \
     apt-get clean -y && \
     pip install -r requirements.txt
 

--- a/start.sh
+++ b/start.sh
@@ -35,7 +35,9 @@ CRONTAB_SCHEDULE=$(jq -r -c ".CRONTAB_SCHEDULE | values" ${ENV_FILE})
 RUN_AT_TIMES=$(jq -r -c ".RUN_AT_TIMES | values" ${ENV_FILE})
 
 echo "Waiting for DB"
-wait-port ${MYSQL_HOST}:${MYSQL_PORT} -t 30000
+while ! nc -z ${MYSQL_HOST} ${MYSQL_PORT}; do   
+  sleep 1 # wait 1 second before check again
+done
 
 echo Running python startups
 python manage.py migrate


### PR DESCRIPTION
The wait-port wasn't working anymore to stop the startup until database starts up, seems easier to just drop that and use netcat. 