### PR TITLE
adding new resource type to event logs

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -160,7 +160,8 @@ def resource_access_within_week(request, course_id=0):
         "week_num_start": week_num_start,
         "week_num_end": week_num_end,
         "grade": grade,
-        "course_id": course_id
+        "course_id": course_id,
+        "resource_type":filter_values
     }
     eventlog(request.user, EventLogTypes.EVENT_VIEW_RESOURCE_ACCESS.value, extra=data)
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -161,7 +161,7 @@ def resource_access_within_week(request, course_id=0):
         "week_num_end": week_num_end,
         "grade": grade,
         "course_id": course_id,
-        "resource_type":filter_values
+        "resource_type": filter_values
     }
     eventlog(request.user, EventLogTypes.EVENT_VIEW_RESOURCE_ACCESS.value, extra=data)
 


### PR DESCRIPTION
Adding the resource type attribute to the Event_logs. This is how it looks

```
{
  "week_num_start":2,
  "week_num_end":4,
  "grade":"All",
  "course_id":17700000000298053,
  "resource_type":[
    "Files",
    "Videos"
  ]
}
```