### PR TITLE
Resolving issue 628: checkbox color, grade toggling, admin handling

### DIFF
--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -41,7 +41,8 @@ function Course (props) {
             <Route path='/courses/:courseId/grades'
               render={props => <GradeDistribution {...props}
                 disabled={!courseInfo.course_view_options.gd}
-                courseId={courseId} />} />
+                courseId={courseId}
+                user={user} />} />
             <Route path='/courses/:courseId/assignments'
               render={props => <AssignmentPlanning {...props}
                 disabled={!courseInfo.course_view_options.ap}

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -30,7 +30,7 @@ const styles = theme => ({
 })
 
 function GradeDistribution (props) {
-  const { classes, disabled, courseId } = props
+  const { classes, disabled, courseId, user } = props
   if (disabled) return (<Error>Grade Distribution view is hidden for this course.</Error>)
 
   const [gradeLoaded, gradeError, gradeData] = useGradeData(courseId)
@@ -60,34 +60,41 @@ function GradeDistribution (props) {
 
   const BuildGradeView = () => {
     const grades = gradeData.map(x => x.current_grade)
+
+    const tableRows = [
+      ['Average grade', <strong>{roundToOneDecimal(average(grades))}%</strong>],
+      ['Median grade', <strong>{roundToOneDecimal(median(grades))}%</strong>],
+      ['Number of students', <strong>{gradeData.length}</strong>],
+      showGrade ?
+        [
+          'My grade',
+          <strong>{
+            gradeData[0].current_user_grade ?
+              `${roundToOneDecimal(gradeData[0].current_user_grade)}%` :
+              'There are no grades yet for you in this course'
+          }</strong>
+        ] : []
+    ]
+
+    const gradeCheckbox = !user.admin ?
+      <> {userSettingLoaded ?
+        <> {'Show my grade'}
+          <Checkbox
+            color='primary'
+            checked={showGrade}
+            onChange={() => {
+              setSettingChanged(true)
+              setShowGrade(!showGrade)
+            }}
+          />
+        </> : <Spinner />}
+      </> : null
+
     return (
       <Grid container>
         <Grid item xs={12} lg={2}>
-          <Table className={classes.table} noBorder tableData={[
-            [
-              'My grade', <strong>{gradeData[0].current_user_grade
-                ? `${roundToOneDecimal(gradeData[0].current_user_grade)}%`
-                : 'There are no grades yet for you in this course'}</strong>
-            ],
-            [
-              'Average grade',
-              <strong>{roundToOneDecimal(average(grades))}%</strong>
-            ],
-            [
-              'Median grade',
-              <strong>{roundToOneDecimal(median(grades))}%</strong>
-            ],
-            ['Number of students', <strong>{gradeData.length}</strong>]
-          ]} />
-          {userSettingLoaded
-            ? <> {'Show my grade'} <Checkbox
-              checked={showGrade}
-              onChange={() => {
-                setSettingChanged(true)
-                setShowGrade(!showGrade)
-              }} />
-            </>
-            : <Spinner />}
+          <Table className={classes.table} noBorder tableData={tableRows} />
+          {gradeCheckbox}
           <UserSettingSnackbar
             saved={userSettingSaved}
             response={userSettingResponse} />


### PR DESCRIPTION
This PR makes modifications to `GradeDistribution.js` and `Course.js` to resolve issue #628. The following changes have been made:

1) The checkbox color for "Show my grade" has been changed to blue (`primary`) to be consistent with with "Resources Accessed" view.

2) A conditional operator was added so that the "My grade" row of the sidebar table disappears and appears (toggles) with the line above the histogram.

3) A conditional operator was added so that the "Show my grade" checkbox only appears when the user is not an admin. Determining a user's admin status required passing the user from the `Course` container to the `GradeDistribution` container as part of `props`.

4) To enhance the readability of the `Grid` being returned from `BuildGradeView`, two new variables -- `tableRows` and `gradeCheckbox` -- were created to store the structures and JSX expressions associated with those elements.

Checks were also made to ensure that the first time a student user sees the "Grade Distribution" view that the "Show My Grade" option is unchecked. Once a selection is made (the box is checked), a new record is created in the MySQL database's user_default_selection table.