### PR TITLE
Add basic GraphQL endpoint

### DIFF
--- a/dashboard/graphql/objects.py
+++ b/dashboard/graphql/objects.py
@@ -1,0 +1,96 @@
+from graphene_django import DjangoObjectType
+import graphene
+
+from django.db.models import Q
+from dashboard.models import DiscussionFlattened, Course, User
+
+import logging
+logger = logging.getLogger(__name__)
+
+class DiscussionUser(DjangoObjectType):
+    user_id = graphene.ID()
+
+    class Meta:
+        model = User
+        only_fields = ('user_id', 'name')
+
+class DiscussionTopicType(DjangoObjectType):
+    topic_id = graphene.ID()
+    course_id = graphene.ID()
+    #assignment_id = graphene.ID()
+    #group_id = graphene.ID()
+    user_id = graphene.ID()
+
+    user = graphene.Field(DiscussionUser)
+
+    class Meta:
+        model = DiscussionFlattened
+        only_fields = ('topic_id', 'course_id', 'user_id', 'title')
+
+    def resolve_user(parent, info):
+        try:
+            user = User.objects.get(
+                user_id=parent.user_id,
+                course_id=parent.course_id
+            )
+            return user
+        except User.DoesNotExist:
+            return None
+
+class DiscussionMessageType(DiscussionTopicType):
+    entry_id = graphene.ID()
+
+    class Meta:
+        model = DiscussionFlattened
+        only_fields = ('topic_id', 'entry_id', 'course_id', 'user_id', 'message')
+
+
+class CourseType(DjangoObjectType):
+    id = graphene.ID()
+    name = graphene.String()
+
+    discussion_topics = graphene.List(DiscussionTopicType)
+    discussion_topic = graphene.Field(DiscussionTopicType,
+        topic_id=graphene.ID())
+
+    discussion_messages = graphene.List(DiscussionMessageType,
+        topic_id=graphene.ID())
+    discussion_message = graphene.Field(DiscussionMessageType,
+        topic_id=graphene.ID(), entry_id=graphene.ID())
+
+    def resolve_discussion_topics(parent, info):
+        return DiscussionFlattened.objects.filter(
+            Q(course_id=parent.id),
+            Q(entry_id=None),
+            Q(group_is_public=True) | Q(group_id=None)
+        )
+
+    def resolve_discussion_topic(parent, info, topic_id):
+        return DiscussionFlattened.objects.get(
+            Q(course_id=parent.id),
+            Q(topic_id=topic_id),
+            Q(entry_id=None),
+            Q(group_is_public=True) | Q(group_id=None)
+        )
+
+    def resolve_discussion_messages(parent, info, **kwargs):
+        logger.info(kwargs)
+        results = DiscussionFlattened.objects.filter(
+            Q(course_id=parent.id),
+            Q(group_is_public=True) | Q(group_id=None)
+        )
+        if kwargs.get('topic_id'):
+            results = results.filter(topic_id=kwargs.get('topic_id'))
+        return results
+
+    def resolve_discussion_message(parent, info, topic_id, entry_id):
+        return DiscussionFlattened.objects.filter(
+            Q(course_id=parent.id),
+            Q(topic_id=topic_id),
+            Q(entry_id=entry_id),
+            Q(group_is_public=True) | Q(group_id=None)
+        )
+
+    class Meta:
+        model = Course
+        only_fields = ('id', 'name')

--- a/dashboard/graphql/query.py
+++ b/dashboard/graphql/query.py
@@ -1,0 +1,42 @@
+from graphene_django import DjangoObjectType
+import graphene
+
+from dashboard.models import Course
+from dashboard.graphql.objects import CourseType
+from dashboard.rules import is_admin_or_enrolled_in_course, is_admin
+from graphql import GraphQLError
+
+class Query(graphene.ObjectType):
+    course = graphene.Field(CourseType, course_id=graphene.ID())
+    courses = graphene.List(CourseType)
+
+    @staticmethod
+    def resolve_course(parent, info, course_id):
+        user = info.context.user
+        if not user.is_authenticated():
+            raise GraphQLError('You must be logged in to access this resource!')
+
+        course = Course.objects.get(id=course_id)
+        if not is_admin_or_enrolled_in_course.test(user, course):
+            raise GraphQLError('You do not have permission to access this resource!')
+
+        return course
+
+    @staticmethod
+    def resolve_courses(parent, info):
+        user = info.context.user
+        if not user.is_authenticated():
+            raise GraphQLError('You must be logged in to access these resource!')
+
+        if is_admin.test(user):
+            return Course.objects.all()
+        else:
+            courses = Course.objects.raw(f"""
+                SELECT course.*
+                FROM course join user on course.id = user.course_id
+                where user.sis_name = '{user.username}'
+            """)
+            return courses
+
+
+schema = graphene.Schema(query=Query)

--- a/dashboard/graphql/schema.py
+++ b/dashboard/graphql/schema.py
@@ -1,0 +1,4 @@
+import graphene
+from dashboard.graphql.query import Query
+
+schema = graphene.Schema(query=Query)

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = [
     'django.contrib.flatpages',
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
+    'graphene_django',
     'django_cron',
     'watchman',
     'macros',
@@ -139,6 +140,10 @@ TEMPLATES = [
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'assets'),
 )
+
+GRAPHENE = {
+    'SCHEMA': 'dashboard.graphql.schema.schema'
+}
 
 WEBPACK_LOADER = {
     'DEFAULT': {

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -20,6 +20,7 @@ from django.contrib.auth.decorators import login_required
 
 from django.views.static import serve
 from django.views.generic.base import TemplateView
+from graphene_django.views import GraphQLView
 
 from django.conf import settings
 from django.conf.urls import include
@@ -43,6 +44,8 @@ urlpatterns = [
     url(r'^courses/', login_required(views.get_home_template,), name="home"),
     url(r'^courses/(?P<course_id>[0-9]+|)', login_required(views.get_course_template,), name="home"),
 
+    # graphql access
+     url('graphql', GraphQLView.as_view(graphiql=True)),
 
     # Thse URL's are data patterns
     # GET access patterns

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,10 @@ django-settings-export>=1.2.1,<1.2.99
 django-macros>=0.4.0,<0.4.99
 django-debug-toolbar>=1.10.1,<1.10.99
 
+# graphql
+graphene-django>=2.4.0,<2.4.99
+django-filter>=2.2.0,<2.2.99
+
 # object-level permissions
 rules>=2.0.1,<2.0.99
 django-model-utils>=3.1.2,<3.1.99


### PR DESCRIPTION
Login & course permissions are checked in the query root course and courses fields (and therefor propagate down)
Currently this only exposes courses, discussions (topics & messages), and a limit user view (just user_id and name) for discussions.
This will be expanded after discussion NLP is completed to fetch those results

Part of #623 