### PR TITLE
#643 adding a check for no students in a particular grade range

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -179,7 +179,7 @@ def resource_access_within_week(request, course_id=0):
     total_number_student = total_number_student_df.iloc[0,0]
     logger.info(f"course_id {course_id} total student={total_number_student}")
     if total_number_student == 0:
-        logger.info(f"For grade {grade} request there are no students in the percent grade range for course {course_id}")
+        logger.info(f"There are no students in the percent grade range {grade} for course {course_id}")
         return HttpResponse("{}")
 
     term_date_start = AcademicTerms.objects.course_date_start(course_id)

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -178,6 +178,9 @@ def resource_access_within_week(request, course_id=0):
     total_number_student_df = pd.read_sql(total_number_student_sql, conn, params={"course_id": course_id})
     total_number_student = total_number_student_df.iloc[0,0]
     logger.info(f"course_id {course_id} total student={total_number_student}")
+    if total_number_student == 0:
+        logger.info(f"For grade {grade} request there are no students in the percent grade range for course {course_id}")
+        return HttpResponse("{}")
 
     term_date_start = AcademicTerms.objects.course_date_start(course_id)
 


### PR DESCRIPTION
Fixes #643 
The issue here is for course that doesn't have student grades in a particular range < 80 and a request from UI comes for that, we just need to recognize that and just return with an empty response. If this is not caught leading to Exception which we want to avoid

Course: 295223