### PR TITLE
Fixing LTI to explicitly use ModelBackend

### DIFF
--- a/dashboard/lti.py
+++ b/dashboard/lti.py
@@ -23,8 +23,8 @@ def valid_lti_request(user_payload, request):
         except User.DoesNotExist:
             password = ''.join(random.sample(string.ascii_letters, RANDOM_PASSWORD_DEFAULT_LENGTH))
             user_obj = User.objects.create_user(username=username, email=email, password=password)
-        # TODO: might have to create an LTI backend since this seems hacky
-        login(request, user_obj, backend=settings.AUTHENTICATION_BACKENDS[0])
+        user_obj.backend = 'django.contrib.auth.backends.ModelBackend'
+        login(request, user_obj)
     else:
         #handle no username from LTI launch
         return HttpResponseRedirect(reverse('django_lti_auth:denied'))

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -372,6 +372,8 @@ else:
 # Give an opportunity to disable LTI
 if ENV.get('STUDENT_DASHBOARD_LTI', False):
     INSTALLED_APPS += ('django_lti_auth',)
+    if not 'django.contrib.auth.backends.ModelBackend' in AUTHENTICATION_BACKENDS:
+        AUTHENTICATION_BACKENDS += ('django.contrib.auth.backends.ModelBackend',)
 
     PYLTI_CONFIG = {
         "consumers": ENV.get("PYLTI_CONFIG_CONSUMERS", {}),


### PR DESCRIPTION
Noticed that `rules.permissions.ObjectPermissionBackend` was interfering with the LTI login (ObjectPermissionBackend doesn't have a get_user function) since it is the first auth method listed after the permissions update. Switching to explicitly using the `django.contrib.auth.backends.ModelBackend` backend (and making sure its a backend available if lti is enabled)