### PR TITLE
Adding method to cron.py to update courses

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -50,6 +50,7 @@ class CourseAdmin(admin.ModelAdmin):
     form = CourseForm
     list_display = ('id', 'canvas_id', 'name', 'term', '_courseviewoption')
     list_select_related = True
+    readonly_fields = ('term',)
 
     # Need this method to correctly display the line breaks
     def _courseviewoption(self, obj):


### PR DESCRIPTION
This PR modifies `cron.py` to use the data for courses already pulled from the data warehouse to update the values for `name`, `term_id`, `date_start`, and `date_end` in course records in the database. This PR aims to resolve issue #457. More details about the changes are provided below.

1) The `verify_course_ids` method in `cron.py` was already running SELECT queries to pull data on each supported course from the data warehouse. The method was modified here to return -- in addition to a list of invalid course ids -- a pandas DataFrame containing all of the course data.

2) A new method was added (and invoked in the `do` method) called `update_course` which takes the DataFrame containing the warehouse course data as a parameter. The method then accesses the existing course records using the Django ORM, and then it loops through the model instances and compares their values to the values in the DataFrame. The method includes logic to only update the values for `name`, `date_start`, and `date_end` when they differ from the values the database is already storing. The related `term` model instance (or `term_id` in the database) is always updated, as the `update_term` method in `cron.py` always deletes the existing records in the `academic_terms` table.