### PR TITLE
Remove remaining code referencing files accessed view

### DIFF
--- a/assets/src/components/AvatarModal.js
+++ b/assets/src/components/AvatarModal.js
@@ -93,8 +93,8 @@ function AvatarModal (props) {
       ? '/grade-distribution'
       : url.includes('assignment')
         ? '/assignment-planning'
-        : url.includes('file')
-          ? '/files-accessed'
+        : url.includes('resources')
+          ? '/resources-accessed'
           : ''
     setHelpURL(`${helpURL}${helpUrlContext}`)
   }, [url])

--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -48,7 +48,7 @@ function Course (props) {
                 disabled={!courseInfo.course_view_options.ap}
                 courseId={courseId} />} />
             <Route path='/courses/:courseId/resources'
-              render={props => <ResourcesAccessed {...props} disabled={!courseInfo.course_view_options.fa} courseInfo={courseInfo}
+              render={props => <ResourcesAccessed {...props} disabled={!courseInfo.course_view_options.ra} courseInfo={courseInfo}
                 courseId={courseId} />} />
           </>
           : <Spinner />

--- a/assets/src/routes/routes.js
+++ b/assets/src/routes/routes.js
@@ -24,7 +24,7 @@ const routes = (courseId, activeViews) => {
       icon: Grade,
       description: 'See what resources you and your peers are viewing.',
       image: '/static/images/file_access_trends_icon.png',
-      viewCode: 'fa'
+      viewCode: 'ra'
     }
   ]
   return allViews.filter(view => activeViews[view.viewCode])

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -214,7 +214,7 @@ class CourseViewOption(models.Model):
         """
 
         try:
-            options = {'fa': int(self.show_resources_accessed and 'show_resources_accessed'
+            options = {'ra': int(self.show_resources_accessed and 'show_resources_accessed'
                                  not in settings.VIEWS_DISABLED),
                        'ap': int(self.show_assignment_planning and 'show_assignment_planning'
                                  not in settings.VIEWS_DISABLED),


### PR DESCRIPTION
This issue fixes the `files access` text that remained after the rename to `resource access`. 

I see that My Learning Analytics Help is still hardcoded to umich one(https://sites.google.com/umich.edu/my-learning-analytics-help/home), not sure if different universities want to have their own Help doc. But the content present in the doc is suitable for all universities.