### PR TITLE
Adding fallback dates to get_course_date_range

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -14,6 +14,9 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from collections import namedtuple
 
+from datetime import datetime, timedelta
+import pytz
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -171,12 +174,16 @@ class Course(models.Model):
     def get_course_date_range(self):
         if self.date_start is not None:
             start = self.date_start
-        else:
+        elif self.term is not None:
             start = self.term.date_start
+        else:
+            start = datetime.now(pytz.UTC)
         if self.date_end is not None:
             end = self.date_end
-        else:
+        elif self.term is not None:
             end = self.term.get_correct_date_end()
+        else:
+            end = start + timedelta(weeks=2)
         DateRange = namedtuple("DateRange", ["start", "end"])
         return DateRange(start, end)
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -108,7 +108,10 @@ def get_course_info(request, course_id=0):
     current_week_number = math.ceil((today - course_start).days/7)
     total_weeks = math.ceil((course_end - course_start).days/7)
 
-    resp['term'] = model_to_dict(course.term)
+    if course.term is not None:
+        resp['term'] = model_to_dict(course.term)
+    else:
+        resp['term'] = None
 
     # Have a fixed maximum number of weeks
     if total_weeks > settings.MAX_DEFAULT_WEEKS:


### PR DESCRIPTION
This PR adds additional logic to the `get_course_date_range` method of the `Course` model to more elegantly handle the case when a `Course` instance has no values for `term`, `date_start`, or `date_end`. In practice, this enables an administrator or developer to view the `/courses` page or any of the views before running `cron.py` (which populates the `term` field of the `Course` instance). The PR aims to resolve issue #665.

Specifically, the changes to `models.py` mean that if `date_start` and `term` are null for a `Course` instance, `get_course_date_range` will return the value of `datetime.datetime.now(pytz.UTC)`. If `date_end` and `term` are null, then `get_course_date_range` will return a DateTime indicating the time two weeks after the course's start (i.e., either the value of `date_start` or the current time). In addition, a minor change was made to `views.py` so that if there is no related `AcademicTerms` instance, `None` is included for the `term` in the response sent to the front-end.