### PR TITLE
Configurable Help URL Through Django Flat Pages

### DIFF
--- a/assets/src/components/AvatarModal.js
+++ b/assets/src/components/AvatarModal.js
@@ -37,13 +37,12 @@ const styles = theme => ({
 })
 
 function AvatarModal (props) {
-  let globals = myla_globals
   const { classes, user } = props
 
   const url = window.location.href
   const logoutURL = '/accounts/logout'
 
-  const [helpURL, setHelpURL] = useState(globals.help_url)
+  const [helpURL, setHelpURL] = useState(user.helpURL)
   const [openChangeCourseDialog, setOpenChangeCourseDialog] = useState(false)
 
   const Admin = () => (

--- a/assets/src/components/AvatarModal.js
+++ b/assets/src/components/AvatarModal.js
@@ -37,12 +37,13 @@ const styles = theme => ({
 })
 
 function AvatarModal (props) {
+  let globals = myla_globals
   const { classes, user } = props
 
   const url = window.location.href
   const logoutURL = '/accounts/logout'
 
-  const [helpURL, setHelpURL] = useState('https://sites.google.com/umich.edu/my-learning-analytics-help/home')
+  const [helpURL, setHelpURL] = useState(globals.help_url)
   const [openChangeCourseDialog, setOpenChangeCourseDialog] = useState(false)
 
   const Admin = () => (

--- a/assets/src/containers/App.js
+++ b/assets/src/containers/App.js
@@ -19,7 +19,8 @@ const user = Object.freeze({
   admin: myla_globals.is_superuser,
   enrolledCourses,
   isSuperuser: myla_globals.is_superuser,
-  isLoggedIn: !!myla_globals.username
+  isLoggedIn: !!myla_globals.username,
+  helpURL: myla_globals.help_url
 })
 
 function App (props) {

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -29,6 +29,9 @@
         }
     </style>
     <script>
+        {%load flatpages%}
+        {%get_flatpages '/help_url/' as flatpages%}
+
         // Setup a top level js object to hold global values
         var myla_globals = {
             "is_superuser": {{user.is_superuser|lower}},
@@ -59,6 +62,11 @@
         {% endif %}
         {% if settings.GA_ID %}
             "google_analytics_id":'{{ settings.GA_ID }}',
+        {% endif %}
+        {% if flatpages %}
+            "help_url": '{{flatpages.first.content|safe}}',
+        {% else %}
+            "help_url": "https://sites.google.com/umich.edu/my-learning-analytics-help/home",
         {% endif %}
         }
         

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -63,7 +63,7 @@
         {% if settings.GA_ID %}
             "google_analytics_id":'{{ settings.GA_ID }}',
         {% endif %}
-        {% if flatpages %}
+        {% if flatpages.first.content %}
             "help_url": '{{flatpages.first.content|safe}}',
         {% else %}
             "help_url": "https://sites.google.com/umich.edu/my-learning-analytics-help/home",


### PR DESCRIPTION
The help URL is now configurable through the Django admin page. Help URLs can now be changed by adding a flat page with the url set as /help_url/ and the content set as the desired url for the help page.

Closes #688.
 