### PR TITLE
Displaying git version info in footer for superusers (#698)

### DIFF
--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -1,23 +1,33 @@
 import logging, os
+from dashboard.settings import SHA_ABBREV_LENGTH
 logger = logging.getLogger(__name__)
+
+
+def convert_github_url_from_ssh_to_https(github_url):
+    ssh_base = "git@github.com"
+    https_base = "https://github.com"
+    # If the URL is formatted for SSH, convert, otherwise, do nothing
+    if ssh_base in github_url:
+        github_url = github_url.replace(":", "/").replace(".git", "").replace(ssh_base, https_base)
+    return github_url
 
 
 def get_build_info():
     logger.debug(get_build_info.__name__)
 
-    commit = os.getenv("OPENSHIFT_BUILD_COMMIT", ""),
-    if commit != "" and len(commit) > 7:
-        commit_abbrev = commit[:7]
+    commit = os.getenv("GIT_COMMIT", "")
+    if commit != "":
+        commit_abbrev = commit[:SHA_ABBREV_LENGTH]
     else:
         commit_abbrev = ""
 
     build = {
-        "build_namespace": os.getenv("OPENSHIFT_BUILD_NAMESPACE", ""),
-        "build_name": os.getenv("OPENSHIFT_BUILD_NAME", ""),
-        "git_source": os.getenv("OPENSHIFT_BUILD_SOURCE", ""),
-        "git_branch": os.getenv("OPENSHIFT_BUILD_REFERENCE", "master"),
+        "git_repo": convert_github_url_from_ssh_to_https(os.getenv("GIT_REPO", "")),
+        "git_branch": os.getenv("GIT_BRANCH", ""),
         "git_commit": commit,
-        "git_commit_abbrev": commit_abbrev
+        "git_commit_abbrev": commit_abbrev,
+        "build_namespace": os.getenv("OPENSHIFT_BUILD_NAMESPACE", None),
+        "build_name": os.getenv("OPENSHIFT_BUILD_NAME", None),
     }
     return build
 

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -3,17 +3,17 @@ from dashboard.settings import SHA_ABBREV_LENGTH
 logger = logging.getLogger(__name__)
 
 
-def convert_github_url_from_ssh_to_https(github_url):
-    ssh_base = "git@github.com"
-    https_base = "https://github.com"
+def format_github_url_using_https(github_url):
+    ssh_base = "git@"
+    https_base = "https://"
     # If the URL is formatted for SSH, convert, otherwise, do nothing
-    if ssh_base in github_url:
+    if ssh_base == github_url[:len(ssh_base)]:
         github_url = github_url.replace(":", "/").replace(".git", "").replace(ssh_base, https_base)
     return github_url
 
 
-def get_build_info():
-    logger.debug(get_build_info.__name__)
+def get_git_version_info():
+    logger.debug(get_git_version_info.__name__)
 
     commit = os.getenv("GIT_COMMIT", "")
     if commit != "":
@@ -21,15 +21,16 @@ def get_build_info():
     else:
         commit_abbrev = ""
 
-    build = {
-        "git_repo": convert_github_url_from_ssh_to_https(os.getenv("GIT_REPO", "")),
-        "git_branch": os.getenv("GIT_BRANCH", ""),
-        "git_commit": commit,
-        "git_commit_abbrev": commit_abbrev,
-        "build_namespace": os.getenv("OPENSHIFT_BUILD_NAMESPACE", None),
-        "build_name": os.getenv("OPENSHIFT_BUILD_NAME", None),
+    # Only include the branch name and not remote info
+    branch = os.getenv("GIT_BRANCH", "").split('/')[-1]
+
+    git_version = {
+        "repo": format_github_url_using_https(os.getenv("GIT_REPO", "")),
+        "commit": commit,
+        "commit_abbrev": commit_abbrev,
+        "branch": branch
     }
-    return build
+    return git_version
 
 
 def look_up_key_for_value(myDict, searchFor):

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -4,12 +4,22 @@ logger = logging.getLogger(__name__)
 
 def get_build_info():
     logger.debug(get_build_info.__name__)
-    git_commit=os.getenv("OPENSHIFT_BUILD_COMMIT", "")
-    build_namespace=os.getenv("OPENSHIFT_BUILD_NAMESPACE", "")
-    git_branch=os.getenv("OPENSHIFT_BUILD_REFERENCE", "master")
-    build_source=os.getenv("OPENSHIFT_BUILD_SOURCE", "")
-    build_name=os.getenv("OPENSHIFT_BUILD_NAME", "")
-    return f'Build_Namespace:{build_namespace} Build_Name: {build_name} Git_Source: {build_source} Git_Branch: {git_branch} Git_Commit: {git_commit}'
+
+    commit = os.getenv("OPENSHIFT_BUILD_COMMIT", ""),
+    if commit != "" and len(commit) > 7:
+        commit_abbrev = commit[:7]
+    else:
+        commit_abbrev = ""
+
+    build = {
+        "build_namespace": os.getenv("OPENSHIFT_BUILD_NAMESPACE", ""),
+        "build_name": os.getenv("OPENSHIFT_BUILD_NAME", ""),
+        "git_source": os.getenv("OPENSHIFT_BUILD_SOURCE", ""),
+        "git_branch": os.getenv("OPENSHIFT_BUILD_REFERENCE", "master"),
+        "git_commit": commit,
+        "git_commit_abbrev": commit_abbrev
+    }
+    return build
 
 
 def look_up_key_for_value(myDict, searchFor):

--- a/dashboard/context_processors.py
+++ b/dashboard/context_processors.py
@@ -15,5 +15,5 @@ def last_updated(request):
     return {'last_updated': db_util.get_canvas_data_date()}
 
 
-def get_build_info(request):
-    return {'build': utils.get_build_info()}
+def get_git_version_info(request):
+    return {'git_version': utils.get_git_version_info()}

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -437,6 +437,9 @@ CANVAS_FILE_ID_NAME_SEPARATOR = "|"
 
 RESOURCE_ACCESS_CONFIG = ENV.get("RESOURCE_ACCESS_CONFIG", {})
 
+# Git info settings
+SHA_ABBREV_LENGTH = 7
+
 # Django CSP Settings, load up from file if set
 if "CSP" in ENV:
     MIDDLEWARE_CLASSES += ['csp.middleware.CSPMiddleware',]

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -132,7 +132,7 @@ TEMPLATES = [
                 'django_settings_export.settings_export',
                 'dashboard.context_processors.current_user_courses_info',
                 'dashboard.context_processors.last_updated',
-                'dashboard.context_processors.get_build_info',
+                'dashboard.context_processors.get_git_version_info',
             ],
         },
     },

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -79,6 +79,34 @@
     {% endblock %}
     {% csrf_token %}
     <footer>
+        {% if user.is_superuser %}
+        <div id="build-info" class="alert alert-info">
+            <table style="width: 100%; padding: 8px; text-align: left">
+                <tr>
+                    <th>Git Source</th>
+                    <th>Git Branch</th>
+                    <th>Git Commit</th>
+                    {% if build.build_namespace %}
+                    <th>Build Namespace</th>
+                    {% endif %}
+                    {% if build.build_namespace %}
+                    <th>Build Name</th>
+                    {% endif %}
+                </tr>
+                <tr>
+                    <td><a href="{{ build.git_repo }}">my-learning-analytics</a></td>
+                    <td>{{ build.git_branch }}</td>
+                    <td><a href="{{ build.git_repo }}/commits/{{ build.git_commit }}">{{ build.git_commit_abbrev }}</a></td>
+                    {% if build.build_namespace %}
+                    <td>{{ build.build_namespace }}</td>
+                    {% endif %}
+                    {% if build.build_namespace %}
+                    <td>{{ build.build_name }}</td>
+                    {% endif %}
+                </tr>
+            </table>
+        </div>
+        {% endif %}
         {% load flatpages %}
         {% get_flatpages '/copyright/' as flatpages %}
         <table style="width: 100%; padding: 8px">
@@ -89,27 +117,6 @@
                 <td style="width: 50%; text-align: right">Data last updated on {{last_updated|date:"m/d/Y P T"}}</td>
             </tr>
         </table>
-        {% if user.is_superuser %}
-        <div id="build-info" class="alert alert-info">
-            <table style="width: 100%; padding: 8px; text-align: left">
-                <tr>
-                    <th>Build Namespace</th>
-                    <th>Build Name</th>
-                    <th>Git Source</th>
-                    <th>Git Branch</th>
-                    <th>Git Commit</th>
-                </tr>
-                <tr>
-                    <!-- Need to add a template tag or some other way to access values-->
-                    <td>{build.build_namespace}</td>
-                    <td>{build.build_name}</td>
-                    <td><a href="{build.git_source}">my-learning-analytics</a></td>
-                    <td>{build.git_branch}</td>
-                    <td><a href="{build.git_source}/commits/{build.git_commit}">{build.git_commit_abbrev}</a></td>
-                </tr>
-            </table>
-        </div>
-        {% endif %}
     </footer>
 </body>
 </html>

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -81,12 +81,34 @@
     <footer>
         {% load flatpages %}
         {% get_flatpages '/copyright/' as flatpages %}
-        <div>
-        <div style="float: left; width: 50%">{{ flatpages.first.content|safe }}</div>
-        <div style="float: left; width: 50%; text-align: right">Data last updated on {{last_updated|date:"m/d/Y P T"}}</div>
-        </div>
+        <table style="width: 100%; padding: 8px">
+            <tr>
+                <td style="width: 50%; text-align: left">
+                    {{ flatpages.first.content|safe }}
+                </td>
+                <td style="width: 50%; text-align: right">Data last updated on {{last_updated|date:"m/d/Y P T"}}</td>
+            </tr>
+        </table>
         {% if user.is_superuser %}
-        <div id="build-info" class="alert alert-info" style="display:none;">{{build}}</div>
+        <div id="build-info" class="alert alert-info">
+            <table style="width: 100%; padding: 8px; text-align: left">
+                <tr>
+                    <th>Build Namespace</th>
+                    <th>Build Name</th>
+                    <th>Git Source</th>
+                    <th>Git Branch</th>
+                    <th>Git Commit</th>
+                </tr>
+                <tr>
+                    <!-- Need to add a template tag or some other way to access values-->
+                    <td>{build.build_namespace}</td>
+                    <td>{build.build_name}</td>
+                    <td><a href="{build.git_source}">my-learning-analytics</a></td>
+                    <td>{build.git_branch}</td>
+                    <td><a href="{build.git_source}/commits/{build.git_commit}">{build.git_commit_abbrev}</a></td>
+                </tr>
+            </table>
+        </div>
         {% endif %}
     </footer>
 </body>

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -79,42 +79,23 @@
     {% endblock %}
     {% csrf_token %}
     <footer>
-        {% if user.is_superuser %}
-        <div id="build-info" class="alert alert-info">
-            <table style="width: 100%; padding: 8px; text-align: left">
-                <tr>
-                    <th>Git Source</th>
-                    <th>Git Branch</th>
-                    <th>Git Commit</th>
-                    {% if build.build_namespace %}
-                    <th>Build Namespace</th>
-                    {% endif %}
-                    {% if build.build_namespace %}
-                    <th>Build Name</th>
-                    {% endif %}
-                </tr>
-                <tr>
-                    <td><a href="{{ build.git_repo }}">my-learning-analytics</a></td>
-                    <td>{{ build.git_branch }}</td>
-                    <td><a href="{{ build.git_repo }}/commits/{{ build.git_commit }}">{{ build.git_commit_abbrev }}</a></td>
-                    {% if build.build_namespace %}
-                    <td>{{ build.build_namespace }}</td>
-                    {% endif %}
-                    {% if build.build_namespace %}
-                    <td>{{ build.build_name }}</td>
-                    {% endif %}
-                </tr>
-            </table>
-        </div>
-        {% endif %}
         {% load flatpages %}
         {% get_flatpages '/copyright/' as flatpages %}
-        <table style="width: 100%; padding: 8px">
+        <table cellspacing="8" style="width: 100%; padding: 8px">
             <tr>
-                <td style="width: 50%; text-align: left">
+                {% if flatpages.first.content %}
+                <td style="text-align: left">
                     {{ flatpages.first.content|safe }}
                 </td>
-                <td style="width: 50%; text-align: right">Data last updated on {{last_updated|date:"m/d/Y P T"}}</td>
+                {% endif %}
+                {% if user.is_superuser %}
+                <td style="text-align: left">
+                    Git version:
+                    <a href="{{ git_version.repo }}/commit/{{ git_version.commit }}">{{ git_version.commit_abbrev }}</a>
+                    (commit), {{ git_version.branch }} (branch)
+                </td>
+                {% endif %}
+                <td style="text-align: left">Data last updated on {{last_updated|date:"m/d/Y P T"}}</td>
             </tr>
         </table>
     </footer>

--- a/start.sh
+++ b/start.sh
@@ -41,8 +41,8 @@ done
 
 echo "Setting Git info variables"
 export GIT_REPO="$(git config --local remote.origin.url)"
-export GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 export GIT_COMMIT="$(git rev-parse HEAD)"
+export GIT_BRANCH="$(git name-rev $GIT_COMMIT --name-only)"
 
 echo Running python startups
 python manage.py migrate

--- a/start.sh
+++ b/start.sh
@@ -39,6 +39,11 @@ while ! nc -z ${MYSQL_HOST} ${MYSQL_PORT}; do
   sleep 1 # wait 1 second before check again
 done
 
+echo "Setting Git info variables"
+export GIT_REPO="$(git config --local remote.origin.url)"
+export GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+export GIT_COMMIT="$(git rev-parse HEAD)"
+
 echo Running python startups
 python manage.py migrate
 


### PR DESCRIPTION
This PR modifies and adds to existing code to expose information to superusers about the Git code version currently in use, specifically the commit and branch. These details are now gathered through git commands in the `start.sh` script, hopefully making the feature available in various environments and across institutions. The code has been tested and appears to be working as expected both locally and deployed to the development instance of MyLA. More details on the changes are provided below. The PR aims to resolve issue #698.

1) Previously, information about the build and Git source was accessed using environment variables only available when running the application in an OpenShift container/pod. After some discussion, we decided the build info was not strictly necessary, and that finding an alternative way of retrieving the Git version details would help make the code portable for other stakeholders. To accomplish this, I created and exported three new variables in `start.sh` for the Git repository, commit, and branch. 

2) To pass these values to the Django template, I needed to update `utils.py` to perform some transformation of values (converting a SSH URL to HTTPS when necessary, abbreviating commits, and removing remote details). I also changed the name of the key function from `get_build_info` to `get_git_version_info` to reflect the simplification of the details exposed. These changes also required tweaks to `context_processors.py` and `settings.py` (in the latter, I also added a new configurable variable `SHA_ABBREV_LENGTH` to control commit abbreviation).

3) Lastly, I modified the `base.html` template to access the Git values and present them neatly in the footer when the user is a superuser. With this, I also changed the layout of the "Copyright" and "Data updated at", placing those values and the new Git version info in a table and adding padding to improve consistency with the rest of the UI. The "Copyright" snippet is now also only conditionally presented when the `flatpage` is present.