### PR TITLE
Add ENV_JSON settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ These instructions will get a copy of MyLA up and running on your local machine 
 1. Download the latest SQL file from this link: https://drive.google.com/drive/u/0/folders/1Pj7roNjRPGyumKKal8-h5E6ukUiXTDI9.
 1. Load database with data. `docker exec -i student_dashboard_mysql mysql -u student_dashboard_user --password=student_dashboard_pw student_dashboard < {name of sql file}`
 
+You may also optionally place the json settings directly into the `ENV_JSON` environment variable if your deployment environment doesn't easily support mounting the `env.json` file into container. When using `ENV_JSON` put the entire contents of `env.json` into it as single line string.
+
 #### Logging in as admininstrator
 1. Navigate to http://localhost:5001/ and log in as:
     ```

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -24,13 +24,16 @@ PROJECT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), ".."),
 )
 
-try:
-    with open(os.getenv("ENV_FILE", "/secrets/env.json")) as f:
-        ENV = json.load(f)
-except FileNotFoundError as fnfe:
-    print("Default config file or one defined in environment variable ENV_FILE not found. This is normal for the build, should define for operation")
-    # Set ENV so collectstatic will still run in the build
-    ENV = os.environ
+if os.getenv("ENV_JSON"):
+    ENV = json.loads(os.getenv("ENV_JSON"))
+else:
+    try:
+        with open(os.getenv("ENV_FILE", "/secrets/env.json")) as f:
+            ENV = json.load(f)
+    except FileNotFoundError as fnfe:
+        print("Default config file or one defined in environment variable ENV_FILE not found. This is normal for the build, should define for operation")
+        # Set ENV so collectstatic will still run in the build
+        ENV = os.environ
 
 LOGOUT_URL = '/accounts/logout'
 LOGIN_URL = '/accounts/login'

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -25,8 +25,10 @@ PROJECT_ROOT = os.path.abspath(
 )
 
 if os.getenv("ENV_JSON"):
+    # optionally load settings from an environment variable
     ENV = json.loads(os.getenv("ENV_JSON"))
 else:
+    # else try loading settings from the json config file
     try:
         with open(os.getenv("ENV_FILE", "/secrets/env.json")) as f:
             ENV = json.load(f)

--- a/start.sh
+++ b/start.sh
@@ -27,12 +27,21 @@ else
     GUNICORN_RELOAD=""
 fi
 
-MYSQL_HOST=$(jq -r -c ".MYSQL_HOST | values" ${ENV_FILE})
-MYSQL_PORT=$(jq -r -c ".MYSQL_PORT | values" ${ENV_FILE})
-IS_CRON_POD=$(jq -r -c ".IS_CRON_POD | values" ${ENV_FILE})
-PTVSD_ENABLE=$(jq -r -c ".PTVSD_ENABLE | values" ${ENV_FILE})
-CRONTAB_SCHEDULE=$(jq -r -c ".CRONTAB_SCHEDULE | values" ${ENV_FILE})
-RUN_AT_TIMES=$(jq -r -c ".RUN_AT_TIMES | values" ${ENV_FILE})
+if [ -z "${ENV_JSON}" ]; then
+    MYSQL_HOST=$(jq -r -c ".MYSQL_HOST | values" ${ENV_FILE})
+    MYSQL_PORT=$(jq -r -c ".MYSQL_PORT | values" ${ENV_FILE})
+    IS_CRON_POD=$(jq -r -c ".IS_CRON_POD | values" ${ENV_FILE})
+    PTVSD_ENABLE=$(jq -r -c ".PTVSD_ENABLE | values" ${ENV_FILE})
+    CRONTAB_SCHEDULE=$(jq -r -c ".CRONTAB_SCHEDULE | values" ${ENV_FILE})
+    RUN_AT_TIMES=$(jq -r -c ".RUN_AT_TIMES | values" ${ENV_FILE})
+else
+    MYSQL_HOST=$(echo "${ENV_JSON}" | jq -r -c ".MYSQL_HOST | values")
+    MYSQL_PORT=$(echo "${ENV_JSON}" | jq -r -c ".MYSQL_PORT | values")
+    IS_CRON_POD=$(echo "${ENV_JSON}" | jq -r -c ".IS_CRON_POD | values")
+    PTVSD_ENABLE=$(echo "${ENV_JSON}" | jq -r -c ".PTVSD_ENABLE | values")
+    CRONTAB_SCHEDULE=$(echo "${ENV_JSON}" | jq -r -c ".CRONTAB_SCHEDULE | values")
+    RUN_AT_TIMES=$(echo "${ENV_JSON}" | jq -r -c ".RUN_AT_TIMES | values")
+fi
 
 echo "Waiting for DB"
 while ! nc -z ${MYSQL_HOST} ${MYSQL_PORT}; do   


### PR DESCRIPTION
Allow loading settings from a JSON encoded environment variables instead of only by json file. This helps support certain deployment situations where it might be hard/impossible to mount a file into the container