### PR TITLE
Grades binning all case so just show Normal distribution

### DIFF
--- a/assets/src/components/d3/createHistogram.js
+++ b/assets/src/components/d3/createHistogram.js
@@ -3,7 +3,7 @@ import { adjustViewport } from '../../util/chart'
 import { roundToOneDecimal } from '../../util/math'
 
 function createHistogram ({ data, width, height, domElement, xAxisLabel, yAxisLabel, myGrade, maxGrade = 100,
-                            showNumberOnBars = false}) {
+                            showNumberOnBars = false, showDashedLine = true}) {
   const margin = { top: 20, right: 20, bottom: 50, left: 40 }
   const [aWidth, aHeight] = adjustViewport(width, height, margin)
 
@@ -15,21 +15,10 @@ function createHistogram ({ data, width, height, domElement, xAxisLabel, yAxisLa
   const binningGrade = tempUniqData[0]
   const firstGradeAfterBinnedGrade = tempUniqData[1]
 
-  // show the binning line only between 2 and 96 grades.
-  const createDashedLine = () => {
-    if (binningGrade > 96) {
-      return false
-    }
-    if (binningGrade < 2) {
-      return false
-    }
-    return true
-  }
-
   /* only showing the tick values above the binned grades eg, with above data the tick will start from 75%
   * if course has 0% or > 95% grades then we just show the whole distribution
   * */
-  const minTickGrade = !createDashedLine() ? 0 : Math.round(firstGradeAfterBinnedGrade / 5) * 5
+  const minTickGrade = showDashedLine ? Math.round(firstGradeAfterBinnedGrade / 5) * 5 : 0
 
   const x = d3.scaleLinear()
     .domain([0, maxGrade]).nice()
@@ -138,7 +127,7 @@ function createHistogram ({ data, width, height, domElement, xAxisLabel, yAxisLa
       .attr('text-anchor', 'start')
   }
   // Dashed line to show difference b/w binned and normal distribution
-  if (createDashedLine()) {
+  if (showDashedLine) {
     svg.append('line')
       .attr(`transform`, `translate(0, ${aHeight - margin.bottom})`)
       .attr('x1', x(dashLine()))

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -107,7 +107,8 @@ function GradeDistribution (props) {
             yAxisLabel={'Number of Students'}
             myGrade={showGrade ? gradeData[0].current_user_grade : null}
             maxGrade={gradeData[0].graph_upper_limit}
-            showNumberOnBars={gradeData[0].show_number_on_bars}/>
+            showNumberOnBars={gradeData[0].show_number_on_bars}
+            showDashedLine={gradeData[0].show_dash_line}/>
         </Grid>
       </Grid>
     )

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -676,9 +676,6 @@ def show_dashed_line(grade, BinningGrade):
         return True
 
 
-
-
-
 def check_if_grade_qualifies_for_binning(grade, fifthElement):
     # case: 96.7, 94.76,
     if int(grade) - int(fifthElement) > 1:
@@ -704,7 +701,7 @@ def binning_logic(grades, fifth_item_in_list):
 
     :param grades: sorted in asc
     :param fifth_item_in_list:
-    :return: max grade in the binned list, length of binned grades, bool value of all grades are being binned
+    :return: max grade in the binned list, length of binned grades, bool value indicating whether all grades are being binned
     """
     binning_list = grades[:5]
     BinningGrade = get_binning_grade()

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -327,8 +327,10 @@ def grade_distribution(request, course_id=0):
     grades = df['current_grade'].values.tolist()
     logger.debug(f"Grades distribution: {grades}")
     BinningGrade = find_binning_grade_value(grades)
-    df['current_grade'] = df['current_grade'].replace(df['current_grade'].head(BinningGrade.index),
+    if BinningGrade is not None and not BinningGrade.binning_all:
+        df['current_grade'] = df['current_grade'].replace(df['current_grade'].head(BinningGrade.index),
                                                       BinningGrade.value)
+    df['show_dash_line'] = show_dashed_line(df['current_grade'].iloc[0], BinningGrade)
 
     if df[df['current_grade'] > 100.0].shape[0] > 0:
         df['graph_upper_limit'] = int((5 * round(float(df['current_grade'].max()) / 5) + 5))
@@ -649,7 +651,7 @@ def find_binning_grade_value(grades):
     next_to_fifth_item = grades[5]
     if next_to_fifth_item - fifth_item > 2:
         BinningGrade = get_binning_grade()
-        return BinningGrade(value=fifth_item, index=4)
+        return BinningGrade(value=fifth_item, index=4, binning_all=False)
     else:
         return binning_logic(grades, fifth_item)
 
@@ -659,6 +661,22 @@ def is_odd(num):
         return False
     else:
         return True
+
+
+def show_dashed_line(grade, BinningGrade):
+    """
+    logic determine to show dashed line or not.
+    :param grade:
+    :param BinningGrade:
+    :return:
+    """
+    if BinningGrade.binning_all or grade > 96 or grade < 2:
+        return False
+    else:
+        return True
+
+
+
 
 
 def check_if_grade_qualifies_for_binning(grade, fifthElement):
@@ -686,7 +704,7 @@ def binning_logic(grades, fifth_item_in_list):
 
     :param grades: sorted in asc
     :param fifth_item_in_list:
-    :return: max grade in the binned list, length of binned grades
+    :return: max grade in the binned list, length of binned grades, bool value of all grades are being binned
     """
     binning_list = grades[:5]
     BinningGrade = get_binning_grade()
@@ -694,11 +712,12 @@ def binning_logic(grades, fifth_item_in_list):
         if check_if_grade_qualifies_for_binning(grade, fifth_item_in_list):
             binning_list.append(grade)
         else:
-            return BinningGrade(max(binning_list), len(binning_list))
+            return BinningGrade(max(binning_list), len(binning_list),False)
+    return BinningGrade(max(binning_list), len(binning_list), True)
 
 
 def get_binning_grade():
-    return namedtuple('BinningGrade', ['value', 'index'])
+    return namedtuple('BinningGrade', ['value', 'index','binning_all'])
 
 def df_default_display_settings():
     pd.set_option('display.max_column', None)


### PR DESCRIPTION
This is the case when all the grades are binned eg [60,70,90, 100, 100, 100, 100, 100, 100, 100]. in this case, the highest binned grade would be 100 and low grader like 60% will be but in the 100% bin and this would be bad. So in case of binning all the grades just show the normal distribution.
 
I think We need to come up with a better design for preserving outlier but that we can tackle in next releases.