### PR TITLE
Fix snackbar sidedrawer issue

### DIFF
--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -8,15 +8,14 @@ function UserSettingSnackbar (props) {
     saved,
     response,
     successMessage = 'Setting saved successfully!',
-    failureMessage = 'Setting not saved.',
-    sideDrawerState
+    failureMessage = 'Setting not saved.'
   } = props
 
   const [savedSnackbarOpen, setSavedSnackbarOpen] = useState(false)
   const [snackbarMessage, setSnackbarMessage] = useState('')
 
   useEffect(() => {
-    if (saved && !sideDrawerState) {
+    if (saved) {
       if (response.default === 'success') {
         setSnackbarMessage(successMessage)
       } else {
@@ -24,7 +23,7 @@ function UserSettingSnackbar (props) {
       }
       setSavedSnackbarOpen(true)
     }
-  })
+  }, [saved])
 
   return (
     <Snackbar

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -8,14 +8,15 @@ function UserSettingSnackbar (props) {
     saved,
     response,
     successMessage = 'Setting saved successfully!',
-    failureMessage = 'Setting not saved.'
+    failureMessage = 'Setting not saved.',
+    sideDrawerState
   } = props
 
   const [savedSnackbarOpen, setSavedSnackbarOpen] = useState(false)
   const [snackbarMessage, setSnackbarMessage] = useState('')
 
   useEffect(() => {
-    if (saved) {
+    if (saved && !sideDrawerState) {
       if (response.default === 'success') {
         setSnackbarMessage(successMessage)
       } else {
@@ -23,7 +24,7 @@ function UserSettingSnackbar (props) {
       }
       setSavedSnackbarOpen(true)
     }
-  }, [saved])
+  })
 
   return (
     <Snackbar

--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -59,7 +59,6 @@ function Course (props) {
                       disabled={!courseInfo.course_view_options.gd}
                       courseId={courseId}
                       user={user}
-                      sideDrawerState={sideDrawerState}
                     />
                 }
               />

--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -9,48 +9,85 @@ import IndexPage from './IndexPage'
 import Spinner from '../components/Spinner'
 import { isObjectEmpty } from '../util/object'
 import { useCourseInfo } from '../service/api'
-import WarningBanner from "../components/WarningBanner"
+import WarningBanner from '../components/WarningBanner'
 
 function Course (props) {
   const { courseId, user } = props
   const [loaded, error, courseInfo] = useCourseInfo(courseId)
   const [sideDrawerState, setSideDrawerState] = useState(false)
 
-  if (error) return (<WarningBanner/>)
+  if (error) return (<WarningBanner />)
   if (loaded && isObjectEmpty(courseInfo)) return (<WarningBanner>My Learning Analytics is not enabled for this course.</WarningBanner>)
 
   return (
     <>
       {
         loaded
-          ? <>
-            <DashboardAppBar
-              onMenuBarClick={setSideDrawerState}
-              sideDrawerState={sideDrawerState}
-              user={user}
-              courseName={courseInfo.name}
-              courseId={courseId} />
-            <SideDrawer
-              toggleDrawer={setSideDrawerState}
-              sideDrawerState={sideDrawerState}
-              courseId={courseId}
-              courseInfo={courseInfo} />
-            <Route path='/courses/:courseId/' exact
-              render={props => <IndexPage {...props}
-                courseInfo={courseInfo} courseId={courseId} />} />
-            <Route path='/courses/:courseId/grades'
-              render={props => <GradeDistribution {...props}
-                disabled={!courseInfo.course_view_options.gd}
+          ? (
+            <>
+              <DashboardAppBar
+                onMenuBarClick={setSideDrawerState}
+                sideDrawerState={sideDrawerState}
+                user={user}
+                courseName={courseInfo.name}
                 courseId={courseId}
-                user={user} />} />
-            <Route path='/courses/:courseId/assignments'
-              render={props => <AssignmentPlanning {...props}
-                disabled={!courseInfo.course_view_options.ap}
-                courseId={courseId} />} />
-            <Route path='/courses/:courseId/resources'
-              render={props => <ResourcesAccessed {...props} disabled={!courseInfo.course_view_options.ra} courseInfo={courseInfo}
-                courseId={courseId} />} />
-          </>
+              />
+              <SideDrawer
+                toggleDrawer={setSideDrawerState}
+                sideDrawerState={sideDrawerState}
+                courseId={courseId}
+                courseInfo={courseInfo}
+              />
+              <Route
+                path='/courses/:courseId/'
+                exact
+                render={
+                  props =>
+                    <IndexPage
+                      {...props}
+                      courseInfo={courseInfo}
+                      courseId={courseId}
+                    />
+                }
+              />
+              <Route
+                path='/courses/:courseId/grades'
+                render={
+                  props =>
+                    <GradeDistribution
+                      {...props}
+                      disabled={!courseInfo.course_view_options.gd}
+                      courseId={courseId}
+                      user={user}
+                      sideDrawerState={sideDrawerState}
+                    />
+                }
+              />
+              <Route
+                path='/courses/:courseId/assignments'
+                render={
+                  props =>
+                    <AssignmentPlanning
+                      {...props}
+                      disabled={!courseInfo.course_view_options.ap}
+                      courseId={courseId}
+                    />
+                }
+              />
+              <Route
+                path='/courses/:courseId/resources'
+                render={
+                  props =>
+                    <ResourcesAccessed
+                      {...props}
+                      disabled={!courseInfo.course_view_options.ra}
+                      courseInfo={courseInfo}
+                      courseId={courseId}
+                    />
+                }
+              />
+            </>
+          )
           : <Spinner />
       }
     </>

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -35,8 +35,7 @@ function GradeDistribution (props) {
     classes,
     disabled,
     courseId,
-    user,
-    sideDrawerState
+    user
   } = props
   if (disabled) return (<AlertBanner>The Grade Distribution view is hidden for this course.</AlertBanner>)
 
@@ -61,8 +60,6 @@ function GradeDistribution (props) {
     settingChanged,
     [showGrade]
   )
-
-  console.log(userSettingSaved)
 
   if (gradeError) return (<WarningBanner />)
 
@@ -108,11 +105,6 @@ function GradeDistribution (props) {
       <Grid container>
         <Grid item xs={12} lg={2}>
           <Table className={classes.table} noBorder tableData={tableRows} />
-          <UserSettingSnackbar
-            saved={userSettingSaved}
-            response={userSettingResponse}
-            sideDrawerState={sideDrawerState}
-          />
         </Grid>
         <Grid item xs={12} lg={10}>
           {gradeCheckbox}
@@ -131,11 +123,9 @@ function GradeDistribution (props) {
     )
   }
 
-  const content = (gradeLoaded && isObjectEmpty(gradeData))
-    ? <AlertBanner>Grade data is not available.</AlertBanner>
-    : gradeLoaded
-      ? <BuildGradeView />
-      : <Spinner />
+  if (gradeLoaded && isObjectEmpty(gradeData)) {
+    return <AlertBanner>Grade data is not available.</AlertBanner>
+  }
 
   return (
     <div className={classes.root}>
@@ -143,7 +133,15 @@ function GradeDistribution (props) {
         <Grid item xs={12}>
           <Paper className={classes.paper}>
             <Typography variant='h5' gutterBottom>Grade Distribution</Typography>
-            {content}
+            {
+              gradeLoaded
+                ? <BuildGradeView />
+                : <Spinner />
+            }
+            <UserSettingSnackbar
+              saved={userSettingSaved}
+              response={userSettingResponse}
+            />
           </Paper>
         </Grid>
       </Grid>

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -31,12 +31,7 @@ const styles = theme => ({
 })
 
 function GradeDistribution (props) {
-  const {
-    classes,
-    disabled,
-    courseId,
-    user
-  } = props
+  const { classes, disabled, courseId, user } = props
   if (disabled) return (<AlertBanner>The Grade Distribution view is hidden for this course.</AlertBanner>)
 
   const [gradeLoaded, gradeError, gradeData] = useGradeData(courseId)

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -31,7 +31,13 @@ const styles = theme => ({
 })
 
 function GradeDistribution (props) {
-  const { classes, disabled, courseId, user } = props
+  const {
+    classes,
+    disabled,
+    courseId,
+    user,
+    sideDrawerState
+  } = props
   if (disabled) return (<AlertBanner>The Grade Distribution view is hidden for this course.</AlertBanner>)
 
   const [gradeLoaded, gradeError, gradeData] = useGradeData(courseId)
@@ -55,6 +61,8 @@ function GradeDistribution (props) {
     settingChanged,
     [showGrade]
   )
+
+  console.log(userSettingSaved)
 
   if (gradeError) return (<WarningBanner />)
 
@@ -103,6 +111,7 @@ function GradeDistribution (props) {
           <UserSettingSnackbar
             saved={userSettingSaved}
             response={userSettingResponse}
+            sideDrawerState={sideDrawerState}
           />
         </Grid>
         <Grid item xs={12} lg={10}>

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -56,67 +56,77 @@ function GradeDistribution (props) {
     [showGrade]
   )
 
-  if (gradeError) return (<WarningBanner/>)
+  if (gradeError) return (<WarningBanner />)
 
   const BuildGradeView = () => {
     const grades = gradeData.map(x => x.current_grade)
 
     const tableRows = [
-      ['Average grade', <strong>{gradeData[0].grade_avg}%</strong>],
-      ['Median grade', <strong>{gradeData[0].median_grade}%</strong>],
-      ['Number of students', <strong>{gradeData[0].tot_students}</strong>],
-      !user.admin && showGrade ?
-        [
+      ['Average grade', <strong key={0}>{gradeData[0].grade_avg}%</strong>],
+      ['Median grade', <strong key={1}>{gradeData[0].median_grade}%</strong>],
+      ['Number of students', <strong key={2}>{gradeData[0].tot_students}</strong>],
+      !user.admin && showGrade
+        ? ([
           'My grade',
-          <strong>{
-            gradeData[0].current_user_grade ?
-              `${roundToOneDecimal(gradeData[0].current_user_grade)}%` :
-              'There are no grades yet for you in this course'
-          }</strong>
-        ] : [],
+          <strong key={0}>
+            {
+              gradeData[0].current_user_grade
+                ? `${roundToOneDecimal(gradeData[0].current_user_grade)}%`
+                : 'There are no grades yet for you in this course'
+            }
+          </strong>
+        ])
+        : []
     ]
 
-    const gradeCheckbox = !user.admin ?
-      <> {userSettingLoaded ?
-        <> <Typography align='right'>{'Show my grade'}
-          <Checkbox
-            color='primary'
-            checked={showGrade}
-            onChange={() => {
-              setSettingChanged(true)
-              setShowGrade(!showGrade)
-            }}
-          /></Typography>
-        </> : <Spinner/>}
-      </> : null
+    const gradeCheckbox = !user.admin
+      ? userSettingLoaded
+        ? (
+          <Typography align='right'>{'Show my grade'}
+            <Checkbox
+              color='primary'
+              checked={showGrade}
+              onChange={() => {
+                setSettingChanged(true)
+                setShowGrade(!showGrade)
+              }}
+            />
+          </Typography>
+        )
+        : <Spinner />
+      : null
 
     return (
       <Grid container>
         <Grid item xs={12} lg={2}>
-          <Table className={classes.table} noBorder tableData={tableRows}/>
+          <Table className={classes.table} noBorder tableData={tableRows} />
           <UserSettingSnackbar
             saved={userSettingSaved}
-            response={userSettingResponse}/>
+            response={userSettingResponse}
+          />
         </Grid>
         <Grid item xs={12} lg={10}>
           {gradeCheckbox}
           <Histogram
             data={grades}
             aspectRatio={0.3}
-            xAxisLabel={'Grade %'}
-            yAxisLabel={'Number of Students'}
+            xAxisLabel='Grade %'
+            yAxisLabel='Number of Students'
             myGrade={showGrade ? gradeData[0].current_user_grade : null}
             maxGrade={gradeData[0].graph_upper_limit}
             showNumberOnBars={gradeData[0].show_number_on_bars}
-            showDashedLine={gradeData[0].show_dash_line}/>
+            showDashedLine={gradeData[0].show_dash_line}
+          />
         </Grid>
       </Grid>
     )
   }
 
-  const content = (gradeLoaded && isObjectEmpty(gradeData)) ?
-      (<AlertBanner>Grade data is not available.</AlertBanner>) :
-      (gradeLoaded ? <BuildGradeView /> : <Spinner />);
+  const content = (gradeLoaded && isObjectEmpty(gradeData))
+    ? <AlertBanner>Grade data is not available.</AlertBanner>
+    : gradeLoaded
+      ? <BuildGradeView />
+      : <Spinner />
 
   return (
     <div className={classes.root}>

--- a/assets/src/containers/SideDrawer.js
+++ b/assets/src/containers/SideDrawer.js
@@ -41,7 +41,8 @@ function SideDrawer (props) {
               button
               key={props.title}
               selected={selectedIndex === key}
-              onClick={() => setSelectedIndex(key)}>
+              onClick={() => setSelectedIndex(key)}
+            >
               <ListItemIcon><props.icon /></ListItemIcon>
               <ListItemText primary={props.title} />
             </ListItem>
@@ -58,7 +59,8 @@ function SideDrawer (props) {
           tabIndex={0}
           role='button'
           onClick={() => toggleDrawer(!sideDrawerState)}
-          onKeyDown={() => toggleDrawer(!sideDrawerState)} >
+          onKeyDown={() => toggleDrawer(!sideDrawerState)}
+        >
           {courseInfo
             ? sideList
             : <Spinner />}

--- a/assets/src/hooks/useSetUserSetting.js
+++ b/assets/src/hooks/useSetUserSetting.js
@@ -13,7 +13,7 @@ const useSetUserSetting = (courseId, userSetting, settingChanged, conditionalArr
       setLoaded(false)
       fetch(`/api/v1/courses/${courseId}/set_user_default_selection`, {
         headers: {
-          'Accept': 'application/json',
+          Accept: 'application/json',
           'X-Requested-With': 'XMLHttpRequest',
           'X-CSRFToken': Cookie.get('csrftoken')
         },


### PR DESCRIPTION
Resolves #705 

The cause was subtle, caused by putting the `UserSettingSnackbar` component within the `buildGradeView` function. This means that every time GradeDistribution rerenders (including any time that the side drawer is opened), a _brand new_ instance of the  `UserSettingSnackbar` component is created, which causes the `useEffect` function within the component to lose track of state, making it render every single time instead of checking the dependency array. 

Took forever to debug 😂 