### PR TITLE
Adding links to courses in the Django admin (#684)

### DIFF
--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -9,10 +9,9 @@
         "127.0.0.1",
         "localhost"
     ],
-    "/* Port the server will use on localhost": "*/",
+    "/* Port in use when the application is running on localhost": "*/",
     "LOCALHOST_PORT": 5001,
     "/* Configuration of CSP see https://django-csp.readthedocs.io/en/latest/configuration.html": "*/",
-    
     "/* To enable this at all you must set have the CSP key set": "*/",
     "/* and REPORT_ONLY should be be false, otherwise it will just console Warn": "*/",
     "CSP": {

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -9,6 +9,8 @@
         "127.0.0.1",
         "localhost"
     ],
+    "/* Port the server will use on localhost": "*/",
+    "LOCALHOST_PORT": 5001,
     "/* Configuration of CSP see https://django-csp.readthedocs.io/en/latest/configuration.html": "*/",
     
     "/* To enable this at all you must set have the CSP key set": "*/",

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -9,8 +9,6 @@
         "127.0.0.1",
         "localhost"
     ],
-    "/* Port in use when the application is running on localhost": "*/",
-    "LOCALHOST_PORT": 5001,
     "/* Configuration of CSP see https://django-csp.readthedocs.io/en/latest/configuration.html": "*/",
     "/* To enable this at all you must set have the CSP key set": "*/",
     "/* and REPORT_ONLY should be be false, otherwise it will just console Warn": "*/",

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django import forms
 from django.conf import settings
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.template.defaultfilters import linebreaksbr
 
@@ -56,6 +57,9 @@ class CourseAdmin(admin.ModelAdmin):
     def _courseviewoption(self, obj):
         return mark_safe(linebreaksbr(obj.courseviewoption))
     _courseviewoption.short_description = "Course View Option(s)"
+
+    def course_link(self, obj):
+        return format_html('<a href="{}">Link</a>', obj.get_absolute_url())
 
     # When saving the course, update the id based on canvas id
     def save_model(self, request, obj, form, change):

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -48,7 +48,7 @@ class CourseForm(forms.ModelForm):
 class CourseAdmin(admin.ModelAdmin):
     inlines = [CourseViewOptionInline, ]
     form = CourseForm
-    list_display = ('canvas_id', 'name', 'term', 'show_grade_counts', '_courseviewoption')
+    list_display = ('canvas_id', 'name', 'term', 'show_grade_counts', 'course_link', '_courseviewoption')
     list_select_related = True
     readonly_fields = ('term',)
 

--- a/dashboard/management/commands/site.py
+++ b/dashboard/management/commands/site.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--domain', dest='domain', type=str, required=True)
+        parser.add_argument('--name', dest='name', type=str, required=True)
+        parser.add_argument('--new', dest='new', type=bool, required=False)
+
+    def handle(self, *args, **options):
+        domain = options.get('domain')
+        name = options.get('name')
+        create_new_site = options.get('new')
+
+        if create_new_site:
+            new_site = Site.objects.create(domain=domain, name=name)
+            new_site.save()
+        else:
+            site_id = settings.SITE_ID
+            default_site = Site.objects.get(id=site_id)
+            default_site.domain = domain
+            default_site.name = name
+            default_site.save()

--- a/dashboard/management/commands/site.py
+++ b/dashboard/management/commands/site.py
@@ -7,7 +7,9 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--domain', dest='domain', type=str, required=True)
         parser.add_argument('--name', dest='name', type=str, required=True)
-        parser.add_argument('--new', dest='new', type=bool, required=False)
+        # Adding a "--new" flag will create a new site record; the site's domain must be unique.
+        # Omitting the flag will update the default record specified in settings.py with the provided values.
+        parser.add_argument('--new', dest='new', action='store_true', required=False)
 
     def handle(self, *args, **options):
         domain = options.get('domain')

--- a/dashboard/management/commands/site.py
+++ b/dashboard/management/commands/site.py
@@ -12,9 +12,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         domain = options.get('domain')
         name = options.get('name')
-        create_new_site = options.get('new')
+        new = options.get('new')
 
-        if create_new_site:
+        if new:
             new_site = Site.objects.create(domain=domain, name=name)
             new_site.save()
         else:

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -12,8 +12,10 @@ from django.db.models import Q
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from collections import namedtuple
+from django.urls import reverse
+from django.utils.html import format_html
 
+from collections import namedtuple
 from datetime import datetime, timedelta
 import pytz
 
@@ -188,6 +190,12 @@ class Course(models.Model):
             end = start + timedelta(weeks=2)
         DateRange = namedtuple("DateRange", ["start", "end"])
         return DateRange(start, end)
+
+    def get_absolute_url(self):
+        return reverse('courses', kwargs={'course_id': self.canvas_id})
+
+    def course_link(self):
+        return format_html('<a href="{}">Link</a>', self.get_absolute_url())
 
     class Meta:
         db_table = "course"

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -13,7 +13,6 @@ from django.db.models import Q
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
-from django.utils.html import format_html
 
 from collections import namedtuple
 from datetime import datetime, timedelta
@@ -193,9 +192,6 @@ class Course(models.Model):
 
     def get_absolute_url(self):
         return reverse('courses', kwargs={'course_id': self.canvas_id})
-
-    def course_link(self):
-        return format_html('<a href="{}">Link</a>', self.get_absolute_url())
 
     class Meta:
         db_table = "course"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - .env
     environment:
       - GUNICORN_RELOAD=True
+      # port in use when the application is running on localhost
+      - LOCALHOST_PORT=5001
     container_name: student_dashboard
   webpack_watcher:
     build:

--- a/start.sh
+++ b/start.sh
@@ -59,7 +59,7 @@ python manage.py migrate
 echo "Setting domain of default site record"
 DOMAIN_JQ='.ALLOWED_HOSTS | . - ["127.0.0.1", "localhost", ".ngrok.io"] | if . | length == 0 then "localhost" else .[0] end'
 DOMAIN=$(jq -r -c "${DOMAIN_JQ}" ${ENV_FILE})
-PORT="$(jq -r -c ".LOCAL_HOST_PORT" ${ENV_FILE})"
+PORT="$(jq -r -c ".LOCALHOST_PORT" ${ENV_FILE})"
 if [ ${DOMAIN} == "localhost" ]; then
   python manage.py site --domain="${DOMAIN}:${PORT}" --name="${DOMAIN}"
 else

--- a/start.sh
+++ b/start.sh
@@ -37,7 +37,7 @@ if [ -z "${ENV_JSON}" ]; then
     CRONTAB_SCHEDULE=$(jq -r -c ".CRONTAB_SCHEDULE | values" ${ENV_FILE})
     RUN_AT_TIMES=$(jq -r -c ".RUN_AT_TIMES | values" ${ENV_FILE})
     DOMAIN=$(jq -r -c "${DOMAIN_JQ} | values" ${ENV_FILE})
-    PORT=$(jq -r -c ".LOCALHOST_PORT | values" ${ENV_FILE})
+    LOCALHOST_PORT=$(jq -r -c ".LOCALHOST_PORT | values" ${ENV_FILE})
 else
     MYSQL_HOST=$(echo "${ENV_JSON}" | jq -r -c ".MYSQL_HOST | values")
     MYSQL_PORT=$(echo "${ENV_JSON}" | jq -r -c ".MYSQL_PORT | values")
@@ -46,7 +46,7 @@ else
     CRONTAB_SCHEDULE=$(echo "${ENV_JSON}" | jq -r -c ".CRONTAB_SCHEDULE | values")
     RUN_AT_TIMES=$(echo "${ENV_JSON}" | jq -r -c ".RUN_AT_TIMES | values")
     DOMAIN=$(echo "${ENV_JSON}" | jq -r -c "${DOMAIN_JQ} | values")
-    PORT=$(echo "${ENV_JSON}" | jq -r -c ".LOCALHOST_PORT | values")
+    LOCALHOST_PORT=$(echo "${ENV_JSON}" | jq -r -c ".LOCALHOST_PORT | values")
 fi
 
 echo "Waiting for DB"
@@ -63,8 +63,12 @@ echo Running python startups
 python manage.py migrate
 
 echo "Setting domain of default site record"
+if [ -z "${LOCALHOST_PORT}" ]; then
+    LOCALHOST_PORT=5001
+fi
+
 if [ ${DOMAIN} == "localhost" ]; then
-  python manage.py site --domain="${DOMAIN}:${PORT}" --name="${DOMAIN}"
+  python manage.py site --domain="${DOMAIN}:${LOCALHOST_PORT}" --name="${DOMAIN}"
 else
   python manage.py site --domain="${DOMAIN}" --name="${DOMAIN}"
 fi

--- a/start.sh
+++ b/start.sh
@@ -56,6 +56,16 @@ export GIT_BRANCH="$(git name-rev $GIT_COMMIT --name-only)"
 echo Running python startups
 python manage.py migrate
 
+echo "Setting domain of default site record"
+DOMAIN_JQ='.ALLOWED_HOSTS | . - ["127.0.0.1", "localhost", ".ngrok.io"] | if . | length == 0 then "localhost" else .[0] end'
+DOMAIN=$(jq -r -c "${DOMAIN_JQ}" ${ENV_FILE})
+PORT="$(jq -r -c ".LOCAL_HOST_PORT" ${ENV_FILE})"
+if [ ${DOMAIN} == "localhost" ]; then
+  python manage.py site --domain="${DOMAIN}:${PORT}" --name="${DOMAIN}"
+else
+  python manage.py site --domain="${DOMAIN}" --name="${DOMAIN}"
+fi
+
 # If these values aren't set or they're set to false
 # This syntax substitutes False if null or unset
 if [ "${IS_CRON_POD:-"false",,}" == "false" ]; then

--- a/start.sh
+++ b/start.sh
@@ -37,7 +37,6 @@ if [ -z "${ENV_JSON}" ]; then
     CRONTAB_SCHEDULE=$(jq -r -c ".CRONTAB_SCHEDULE | values" ${ENV_FILE})
     RUN_AT_TIMES=$(jq -r -c ".RUN_AT_TIMES | values" ${ENV_FILE})
     DOMAIN=$(jq -r -c "${DOMAIN_JQ} | values" ${ENV_FILE})
-    LOCALHOST_PORT=$(jq -r -c ".LOCALHOST_PORT | values" ${ENV_FILE})
 else
     MYSQL_HOST=$(echo "${ENV_JSON}" | jq -r -c ".MYSQL_HOST | values")
     MYSQL_PORT=$(echo "${ENV_JSON}" | jq -r -c ".MYSQL_PORT | values")
@@ -46,7 +45,6 @@ else
     CRONTAB_SCHEDULE=$(echo "${ENV_JSON}" | jq -r -c ".CRONTAB_SCHEDULE | values")
     RUN_AT_TIMES=$(echo "${ENV_JSON}" | jq -r -c ".RUN_AT_TIMES | values")
     DOMAIN=$(echo "${ENV_JSON}" | jq -r -c "${DOMAIN_JQ} | values")
-    LOCALHOST_PORT=$(echo "${ENV_JSON}" | jq -r -c ".LOCALHOST_PORT | values")
 fi
 
 echo "Waiting for DB"
@@ -63,10 +61,7 @@ echo Running python startups
 python manage.py migrate
 
 echo "Setting domain of default site record"
-if [ -z "${LOCALHOST_PORT}" ]; then
-    LOCALHOST_PORT=5001
-fi
-
+# The value for LOCALHOST_PORT is set in docker-compose.yml
 if [ ${DOMAIN} == "localhost" ]; then
   python manage.py site --domain="${DOMAIN}:${LOCALHOST_PORT}" --name="${DOMAIN}"
 else


### PR DESCRIPTION
This PR makes changes to the Django back-end and `start.sh` in order to provide convenient links in the Django admin to course landing pages in the MyLA front-end. Besides making changes to `models.py` and `admin.py`, I created a new environment variable `LOCALHOST_PORT` and added a new management command `site` so that the domain could be set automatically through `start.sh`. I have tested this locally and on [the MyLA development instance](https://dev-myla.tl.it.umich.edu), where the changes are still deployed (as of the morning of 10/14). More details on the changes are provided below. This PR aims to resolve issue #684.

1) Adding a "View on Site" link to the Course edit page and a field link in the Course list view was relatively straightforward. The former was created automatically once `get_absolute_url` was added as a method to the `Course` model. I then created the list view link by adding a `course_link` method to the `CourseAdmin` model, which could then be included in the `list_display` link. Using [`format_html`](https://docs.djangoproject.com/en/2.2/ref/utils/) seems to be a best practice for preparing small HTML fragments.

2) However, because calling `reverse` pulls in the value for the domain from the `django_site` table in the MySQL database (which was previously `example.com`), I needed a flexible way to set the domain that would work in all the environments the application is run in. The solution I arrived at (there may be others) was to create a new `site` management command that could be invoked from `start.sh`. The new command allows for either the creation of a new site record (using the `--new` flag) or the updating of the default site, which is identified by importing the `SITE_ID` variable from `settings.py`.

3) To isolate the inputs for the new `site` command within `start.sh`, I needed to create a new environment variable `LOCALHOST_PORT` and filter the existing `ALLOWED_HOSTS` array in the `env.json` file. I could not find a place where the port used with `localhost` was specified except in `docker-compose.yml`, and it seemed strange to pull the value from there. Note: for the links to work, reviewers will need to set `LOCALHOST_PORT` if their port differs from the default value of `5001`. I used a [jq](https://stedolan.github.io/jq/manual/v1.5/) query to filter `ALLOWED_HOSTS` down to either a default `localhost` or whatever domain is being used in a deployed instance. Then the `site` command is invoked using either `localhost` and the specified port or simply the provided domain.

Feedback is welcome, and to ensure this works for other institutions, it would be great if someone from UBC could review and test this.