### PR TITLE
Adding demo_init.sh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 saml
 bq_cred.json
 env.json
+demo_init.sh
 .idea/
 .DS_Store
 


### PR DESCRIPTION
This PR adds `demo_init.sh` to the repo's `.gitignore` to ensure that those that make use of `demo_init.sh.sample` do not accidentally commit the 'un-sampled' file (and possibly expose data they add to it). The PR aims to resolve issue #755.