### PR TITLE
Fetching all terms using cron (#758)

### DIFF
--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -113,8 +113,6 @@
     "DJANGO_WATCHMAN_TOKEN": "",
     "/*  A single default IDP to use if multiple are present in the SAML metadata (Get from Metadata)": "*/",
     "DJANGO_SAML2_DEFAULT_IDP": "",
-    "/*  Earliest term date from database that we'll show and support academic terms from (default is 2016-11-15 which the first date of 'our' data)": "*/",
-    "EARLIEST_TERM_DATE": "2016-11-15",
     "/*  CRON POD SETTINGS": "*/",
     "/* ": "*/",
     "/*  All of these settings go together and need to be enabled for cron job": "*/",

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -300,7 +300,6 @@ class DashboardCronJob(CronJobBase):
 
             # First update the resource table
             # write to MySQL
-            print(resource_df.head())
             try:
                 resource_df.to_sql(con=engine, name='resource', if_exists='append', index=False)
             except Exception as e:

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -300,6 +300,7 @@ class DashboardCronJob(CronJobBase):
 
             # First update the resource table
             # write to MySQL
+            print(resource_df.head())
             try:
                 resource_df.to_sql(con=engine, name='resource', if_exists='append', index=False)
             except Exception as e:
@@ -430,8 +431,8 @@ class DashboardCronJob(CronJobBase):
         # delete all records in the table first
         status += deleteAllRecordInTable("academic_terms")
 
-        #select term records from DATA_WAREHOUSE
-        term_sql = f"select id, canvas_id, name, date_start, date_end from enrollment_term_dim where date_start > '{settings.EARLIEST_TERM_DATE}'"
+        # select term records from DATA_WAREHOUSE
+        term_sql = "SELECT id, canvas_id, name, date_start, date_end FROM enrollment_term_dim;"
         logger.debug(term_sql)
         status += util_function(None, term_sql, 'academic_terms')
 

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -176,15 +176,17 @@ class Course(models.Model):
     def get_course_date_range(self):
         if self.date_start is not None:
             start = self.date_start
-        elif self.term is not None:
+        elif self.term is not None and self.term.date_start is not None:
             start = self.term.date_start
         else:
+            logger.warning("No date_start value was found for course or term; setting to current date and time")
             start = datetime.now(pytz.UTC)
         if self.date_end is not None:
             end = self.date_end
-        elif self.term is not None:
+        elif self.term is not None and self.term.date_end is not None:
             end = self.term.get_correct_date_end()
         else:
+            logger.warning("No date_end value was found for course or term; setting to two weeks from now")
             end = start + timedelta(weeks=2)
         DateRange = namedtuple("DateRange", ["start", "end"])
         return DateRange(start, end)

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -410,10 +410,6 @@ CANVAS_DATA_ID_INCREMENT = ENV.get("CANVAS_DATA_ID_INCREMENT", 17700000000000000
 # Allow enabling/disabling the View options globally
 VIEWS_DISABLED = ENV.get('VIEWS_DISABLED', [])
 
-# This is to set a date so that MyLA will track all terms with start date after this date.
-
-EARLIEST_TERM_DATE = ENV.get('EARLIEST_TERM_DATE', '2016-11-15')
-
 # Time to run cron
 RUN_AT_TIMES = ENV.get('RUN_AT_TIMES', [])
 


### PR DESCRIPTION
This PR includes a modification to the `update_term` method of `cron.py` to bring in all term records available from the Unizin Data Warehouse, as well as some changes to the handling of term dates in the `get_course_date_range` method. See below for additional explanation and details. The PR aims to resolve issue #758.

1) Previously, the terms fetched were limited (using a `WHERE` clause) to those before an `EARLIEST_TERM_DATE` specified as an environment variable. Removing this clause brings in terms earlier than the date previously specified, as well as terms without dates, (e.g. "No Term" or "Default Term") to the local database.

2) Because some of the new terms pulled using `cron.py` do not have dates, I added some additional handling to the `get_course_date_range` method of the `Course` model. When `self.term.date_start` or `self.term.date_end` are `None`, the fallback dates set in PR #690 are used. I also added some `warning` logs that are triggered in all cases when the fallback dates are used to help with application maintenance.

3) Because `EARLIEST_TERM_DATE` is no longer used, I removed the references to this variable from `settings.py` and `env_sample.json`.

Note: This PR brings in all the term values, but more investigation would need to be done to ensure  proper handling of courses that have dates that span beyond the limits of a single term (based on dates set at the course level). When supporting these courses, we would need to look at modifying the `MAX_DEFAULT_WEEKS` variable.