### PR TITLE
Changed tooltip text in resource accessed view

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -19,11 +19,11 @@ const toolTip = d3tip().attr('class', 'd3-tip')
   .direction('n').offset([-5, 5])
   .html(d => {
     if (d.self_access_count === 0) {
-      return `<b>You haven't viewed this resource. </b>`
+      return `<b>You haven't accessed this resource. </b>`
     } else if (d.self_access_count === 1) {
-      return `You have read the resource once on ${new Date(d.self_access_last_time).toDateString()}.`
+      return `You have accessed this resource once on ${new Date(d.self_access_last_time).toDateString()}.`
     } else {
-      return `You have read the resource ${d.self_access_count} times. The last time you accessed this resource was on ${new Date(d.self_access_last_time).toDateString()}.`
+      return `You have accsessed this resource ${d.self_access_count} times. The last time you accessed this resource was on ${new Date(d.self_access_last_time).toDateString()}.`
     }
   })
 


### PR DESCRIPTION
This PR addresses the issue in the Resource Access view where the tool tips currently say "read" which  does not make sense for videos or other types of resources that are not read. This PR changes the text to "accessed." 

Closes #724 