### PR TITLE
Moving myla_globals construction to views.py (#779)

### DIFF
--- a/assets/src/components/AvatarModal.js
+++ b/assets/src/components/AvatarModal.js
@@ -77,7 +77,7 @@ function AvatarModal (props) {
       >
         <DialogTitle>Select a course</DialogTitle>
         <List>
-          {user.enrolledCourses.map((course, i) => (
+          {user.relatedCourses.map((course, i) => (
             <Link
               style={{ textDecoration: 'none' }}
               href={`/courses/${course.course_id}`}
@@ -143,7 +143,7 @@ function AvatarModal (props) {
                 : null
             }
             {
-              user.enrolledCourses.length > 1
+              user.relatedCourses.length > 1
                 ? SwitchCourses()
                 : null
             }

--- a/assets/src/containers/App.js
+++ b/assets/src/containers/App.js
@@ -29,8 +29,6 @@ function App (props) {
   const coursePageMatch = matchPath(location.pathname, '/courses/:courseId/')
   const courseId = coursePageMatch ? coursePageMatch.params.courseId : null
 
-  console.log(user);
-
   return (
     <>
       <GoogleAnalyticsTracking gaId={myla_globals.google_analytics_id} />

--- a/assets/src/containers/App.js
+++ b/assets/src/containers/App.js
@@ -29,6 +29,8 @@ function App (props) {
   const coursePageMatch = matchPath(location.pathname, '/courses/:courseId/')
   const courseId = coursePageMatch ? coursePageMatch.params.courseId : null
 
+  console.log(user);
+
   return (
     <>
       <GoogleAnalyticsTracking gaId={myla_globals.google_analytics_id} />

--- a/assets/src/containers/App.js
+++ b/assets/src/containers/App.js
@@ -6,10 +6,6 @@ import GoogleAnalyticsTracking from '../components/GoogleAnalyticsTracking'
 import CourseList from './CourseList'
 import Course from './Course'
 
-const enrolledCourses = (myla_globals.user_courses_info.length !== 0)
-  ? JSON.parse(myla_globals.user_courses_info)
-  : ''
-
 /*
 Frozen to prevent unintentional changes to this object. This object is strictly readonly.
 myla_globals should ONLY be accessed in App.js, and nowhere else.
@@ -17,7 +13,7 @@ myla_globals should ONLY be accessed in App.js, and nowhere else.
 const user = Object.freeze({
   username: myla_globals.username,
   admin: myla_globals.is_superuser,
-  enrolledCourses,
+  relatedCourses: myla_globals.user_courses_info,
   isSuperuser: myla_globals.is_superuser,
   isLoggedIn: !!myla_globals.username,
   helpURL: myla_globals.help_url

--- a/assets/src/containers/CourseList.js
+++ b/assets/src/containers/CourseList.js
@@ -11,7 +11,7 @@ import IconButton from '@material-ui/core/IconButton'
 import Avatar from '@material-ui/core/Avatar'
 import Popover from '@material-ui/core/Popover'
 import AvatarModal from '../components/AvatarModal'
-import WarningBanner from '../components/WarningBanner'
+import AlertBanner from '../components/AlertBanner'
 
 const styles = theme => ({
   root: {
@@ -43,10 +43,6 @@ const styles = theme => ({
 
 function CourseList (props) {
   const { classes, user } = props
-
-  if (!user.enrolledCourses && !user.isSuperuser) {
-    return (<WarningBanner>You are not enrolled in any courses with My Learning Analytics enabled.</WarningBanner>)
-  }
 
   const [avatarEl, setAvatarEl] = useState(null)
   const avatarOpen = Boolean(avatarEl)
@@ -85,25 +81,19 @@ function CourseList (props) {
         </Toolbar>
       </AppBar>
       <div className={classes.content}>
-        {
-          user.isSuperuser
-            ? <Grid container spacing={2}>
-                <Grid item xs={12}>
-                  <Paper className={classes.paper}>
-                    <Typography variant='h5' gutterBottom>Select a course of your choice</Typography>
-                  </Paper>
-                </Grid>
-              </Grid>
-            : <Grid container spacing={2}>
-                <Grid item xs={12} className={classes.container}>
-                  {user.enrolledCourses.map((course, key) =>
-                    <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
-                      <SelectCard cardData={{ title: course.course_name }} />
-                    </Link>
-                  )}
-                </Grid>
-              </Grid>
-        }
+        <Grid container spacing={2}>
+          <Grid item xs={12} className={classes.container}>
+            {
+              (user.relatedCourses.length === 0) ?
+                (<AlertBanner>You are not enrolled in any courses with My Learning Analytics enabled.</AlertBanner>)
+              : user.relatedCourses.map((course, key) =>
+                (<Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
+                  <SelectCard cardData={{ title: course.course_name }} />
+                </Link>)
+              )
+            }
+          </Grid>
+        </Grid>
       </div>
     </>
   )

--- a/assets/src/containers/CourseList.js
+++ b/assets/src/containers/CourseList.js
@@ -97,9 +97,9 @@ function CourseList (props) {
             : <Grid container spacing={2}>
                 <Grid item xs={12} className={classes.container}>
                   {user.relatedCourses.map((course, key) =>
-                      <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
-                        <SelectCard cardData={{ title: course.course_name }} />
-                      </Link>
+                    <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
+                      <SelectCard cardData={{ title: course.course_name }} />
+                    </Link>
                   )}
                 </Grid>
               </Grid>

--- a/assets/src/containers/CourseList.js
+++ b/assets/src/containers/CourseList.js
@@ -88,21 +88,21 @@ function CourseList (props) {
         {
           user.isSuperuser
             ? <Grid container spacing={2}>
-              <Grid item xs={12}>
-                <Paper className={classes.paper}>
-                  <Typography variant='h5' gutterBottom>Select a course of your choice</Typography>
-                </Paper>
+                <Grid item xs={12}>
+                  <Paper className={classes.paper}>
+                    <Typography variant='h5' gutterBottom>Select a course of your choice</Typography>
+                  </Paper>
+                </Grid>
               </Grid>
-            </Grid>
             : <Grid container spacing={2}>
-              <Grid item xs={12} className={classes.container}>
-                {user.relatedCourses.map((course, key) =>
-                    <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
-                      <SelectCard cardData={{ title: course.course_name }} />
-                    </Link>
-                )}
+                <Grid item xs={12} className={classes.container}>
+                  {user.relatedCourses.map((course, key) =>
+                      <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
+                        <SelectCard cardData={{ title: course.course_name }} />
+                      </Link>
+                  )}
+                </Grid>
               </Grid>
-            </Grid>
         }
       </div>
     </>

--- a/assets/src/containers/CourseList.js
+++ b/assets/src/containers/CourseList.js
@@ -11,7 +11,7 @@ import IconButton from '@material-ui/core/IconButton'
 import Avatar from '@material-ui/core/Avatar'
 import Popover from '@material-ui/core/Popover'
 import AvatarModal from '../components/AvatarModal'
-import AlertBanner from '../components/AlertBanner'
+import WarningBanner from '../components/WarningBanner'
 
 const styles = theme => ({
   root: {
@@ -43,6 +43,10 @@ const styles = theme => ({
 
 function CourseList (props) {
   const { classes, user } = props
+
+  if (!user.relatedCourses && !user.isSuperuser) {
+    return (<WarningBanner>You are not enrolled in any courses with My Learning Analytics enabled.</WarningBanner>)
+  }
 
   const [avatarEl, setAvatarEl] = useState(null)
   const avatarOpen = Boolean(avatarEl)
@@ -81,19 +85,25 @@ function CourseList (props) {
         </Toolbar>
       </AppBar>
       <div className={classes.content}>
-        <Grid container spacing={2}>
-          <Grid item xs={12} className={classes.container}>
-            {
-              (user.relatedCourses.length === 0) ?
-                (<AlertBanner>You are not enrolled in any courses with My Learning Analytics enabled.</AlertBanner>)
-              : user.relatedCourses.map((course, key) =>
-                (<Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
-                  <SelectCard cardData={{ title: course.course_name }} />
-                </Link>)
-              )
-            }
-          </Grid>
-        </Grid>
+        {
+          user.isSuperuser
+            ? <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <Paper className={classes.paper}>
+                  <Typography variant='h5' gutterBottom>Select a course of your choice</Typography>
+                </Paper>
+              </Grid>
+            </Grid>
+            : <Grid container spacing={2}>
+              <Grid item xs={12} className={classes.container}>
+                {user.relatedCourses.map((course, key) =>
+                    <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
+                      <SelectCard cardData={{ title: course.course_name }} />
+                    </Link>
+                )}
+              </Grid>
+            </Grid>
+        }
       </div>
     </>
   )

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -85,7 +85,7 @@ def get_default_user_course_id(user_id):
 def get_user_courses_info(user_id):
     logger.info(get_user_courses_info.__name__)
     course_list = []
-    course_info={}
+    course_info = []
     with django.db.connection.cursor() as cursor:
         cursor.execute("SELECT course_id FROM user WHERE sis_name= %s", [user_id])
         courses = cursor.fetchall()
@@ -99,9 +99,9 @@ def get_user_courses_info(user_id):
             cursor.execute("select canvas_id, name from course where canvas_id in %s",[course_tuple])
             course_names = cursor.fetchall()
             df = pd.DataFrame(list(course_names))
-            df.columns=["course_id", "course_name"]
-            course_info=df.to_json(orient='records')
-            logger.info(f"User {user_id} is enrolled in courses {course_info}")
+            df.columns = ["course_id", "course_name"]
+            course_info = df.to_dict(orient='records')
+            logger.info(f"User {user_id} is affiliated with these courses {df.to_json(orient='records')}")
     return course_info
 
 

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -103,7 +103,7 @@ def get_user_courses_info(username):
             df = pd.DataFrame(list(course_names))
             df.columns = ["course_id", "course_name"]
             course_info = df.to_dict(orient='records')
-            logger.info(f"User {username} is enrolled in these courses {df.to_json(orient='records')}")
+            logger.info(f"User {username} is enrolled in these courses: {course_info}")
     return course_info
 
 

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -84,12 +84,12 @@ def get_default_user_course_id(user_id):
     return course_id
 
 
-def get_user_courses_info(user_id):
+def get_user_courses_info(username):
     logger.info(get_user_courses_info.__name__)
     course_list = []
     course_info = []
     with django.db.connection.cursor() as cursor:
-        cursor.execute("SELECT course_id FROM user WHERE sis_name= %s", [user_id])
+        cursor.execute("SELECT course_id FROM user WHERE sis_name= %s", [username])
         courses = cursor.fetchall()
         if courses is not None:
             for course in courses:
@@ -103,7 +103,7 @@ def get_user_courses_info(user_id):
             df = pd.DataFrame(list(course_names))
             df.columns = ["course_id", "course_name"]
             course_info = df.to_dict(orient='records')
-            logger.info(f"User {user_id} is enrolled in these courses {df.to_json(orient='records')}")
+            logger.info(f"User {username} is enrolled in these courses {df.to_json(orient='records')}")
     return course_info
 
 

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -11,6 +11,7 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
+
 def canvas_id_to_incremented_id(canvas_id):
     try:
         int(canvas_id)
@@ -19,6 +20,7 @@ def canvas_id_to_incremented_id(canvas_id):
 
     return int(canvas_id) + settings.CANVAS_DATA_ID_INCREMENT
 
+
 def incremented_id_to_canvas_id(incremented_id):
     try:
         int(incremented_id)
@@ -26,6 +28,7 @@ def incremented_id_to_canvas_id(incremented_id):
         return None
 
     return str(int(incremented_id) - settings.CANVAS_DATA_ID_INCREMENT)
+
 
 def get_course_name_from_id(course_id):
     """[Get the long course name from the id]
@@ -48,7 +51,6 @@ def get_course_name_from_id(course_id):
 
 
 def get_course_view_options (course_id):
-
     logger.info(get_course_view_options.__name__)
     course_id = canvas_id_to_incremented_id(course_id)
     logger.debug("course_id=" + str(course_id))
@@ -101,7 +103,7 @@ def get_user_courses_info(user_id):
             df = pd.DataFrame(list(course_names))
             df.columns = ["course_id", "course_name"]
             course_info = df.to_dict(orient='records')
-            logger.info(f"User {user_id} is affiliated with these courses {df.to_json(orient='records')}")
+            logger.info(f"User {user_id} is enrolled in these courses {df.to_json(orient='records')}")
     return course_info
 
 
@@ -113,6 +115,7 @@ def get_last_cron_run():
     except CronJobLog.DoesNotExist:
         logger.info("CronJobLog did not exist", exc_info = True)
     return datetime.min
+
 
 def get_canvas_data_date():
     if not settings.DATA_WAREHOUSE_IS_UNIZIN:

--- a/dashboard/context_processors.py
+++ b/dashboard/context_processors.py
@@ -5,12 +5,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def current_user_courses_info(request):
-    logger.info(current_user_courses_info.__name__)
-    courses_info_by_user = db_util.get_user_courses_info(request.user.username)
-    return {'current_user_courses_info': courses_info_by_user}
-
-
 def last_updated(request):
     return {'last_updated': db_util.get_canvas_data_date()}
 

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -135,7 +135,6 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'django_su.context_processors.is_su',
                 'django_settings_export.settings_export',
-                'dashboard.context_processors.current_user_courses_info',
                 'dashboard.context_processors.last_updated',
                 'dashboard.context_processors.get_git_version_info',
             ],

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -29,45 +29,7 @@
         }
     </style>
     <script>
-        {%load flatpages%}
-        {%get_flatpages '/help_url/' as flatpages%}
-
-        // Setup a top level js object to hold global values
-        var myla_globals = {
-            "is_superuser": {{user.is_superuser|lower}},
-        {% if user.is_authenticated %}
-            "username": '{{ user.get_username }}',
-        {% else %}
-            "username": "",
-        {% endif %}
-        {% if settings.LOGIN_URL  %}
-            "login": '{{ settings.LOGIN_URL }}',
-        {% else %}
-            "login": "",
-        {% endif %}
-        {% if settings.LOGOUT_URL  %}
-            "logout": '{{ settings.LOGOUT_URL }}',
-        {% else %}
-            "logout": "",
-        {% endif %}
-        {% if user.is_authenticated%}
-            "user_courses_info":'{{current_user_courses_info|safe}}',
-        {% else %}
-            "user_courses_info": "",
-        {% endif %}
-        {% if settings.GA_ID %}
-            "google_analytics_id":'{{ settings.GA_ID }}',
-        {% else %}
-            "google_analytics_id": "",
-        {% endif %}
-        {% if flatpages.first.content %}
-            "help_url": '{{flatpages.first.content|safe}}',
-        {% else %}
-            "help_url": "https://sites.google.com/umich.edu/my-learning-analytics-help/home",
-        {% endif %}
-        }
-        
-
+        const myla_globals = {{ myla_globals | safe }};
     </script>
 </head>
 <body>

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -80,7 +80,7 @@ def get_home_template(request):
     if settings.GA_ID:
         google_analytics_id = settings.GA_ID
     flatpages = FlatPage.objects.all()
-    if len(flatpages) != 0:
+    if flatpages:
         help_url = flatpages[0].content
     else:
         help_url = "https://sites.google.com/umich.edu/my-learning-analytics-help/home"
@@ -95,10 +95,7 @@ def get_home_template(request):
         "help_url": help_url
     }
 
-    logger.info(myla_globals)
-    myla_globals_json = json.dumps(myla_globals)
-    logger.info(myla_globals_json)
-    return render(request, 'frontend/index.html', context={'myla_globals': myla_globals_json})
+    return render(request, 'frontend/index.html', context={'myla_globals': json.dumps(myla_globals)})
 
 
 @permission_required('dashboard.get_course_template',
@@ -768,7 +765,6 @@ def logout(request):
     return redirect(settings.LOGOUT_REDIRECT_URL)
 
 
-
 def courses_enabled(request):
     """ Returns json for all courses we currently support and are enabled """
     
@@ -781,7 +777,7 @@ def courses_enabled(request):
         # Return json
         if callback is None:
             return HttpResponse(json.dumps(data), content_type='application/json')
-        # Return jsonp
+        # Return json
         else:
             return HttpResponse("{0}({1})".format(callback, json.dumps(data)), content_type='application/json')
     else:

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -2,19 +2,20 @@ from django.forms.models import model_to_dict
 from rules.contrib.views import permission_required, objectgetter
 
 import math, json, logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.utils import timezone
 
 import numpy as np
 import pandas as pd
 from django.conf import settings
 from django.contrib import auth
+from django.contrib.flatpages.models import FlatPage
 from django.db import connection as conn
 from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import redirect, render
 from pinax.eventlog.models import log as eventlog
 from dashboard.event_logs_types.event_logs_types import EventLogTypes
-from dashboard.common.db_util import canvas_id_to_incremented_id
+from dashboard.common.db_util import canvas_id_to_incremented_id, get_user_courses_info
 from dashboard.common import utils
 from django.core.exceptions import ObjectDoesNotExist
 from collections import namedtuple
@@ -60,7 +61,44 @@ def gpa_map(grade):
 
 
 def get_home_template(request):
-    return render(request, 'frontend/index.html')
+    username = ""
+    user_courses_info = []
+    login_url = ""
+    logout_url = ""
+    google_analytics_id = ""
+
+    current_user = request.user
+    is_superuser = current_user.is_superuser
+    if current_user.is_authenticated:
+        username = current_user.get_username()
+        user_courses_info = get_user_courses_info(username)
+
+    if settings.LOGIN_URL:
+        login_url = settings.LOGIN_URL
+    if settings.LOGOUT_URL:
+        logout_url = settings.LOGOUT_URL
+    if settings.GA_ID:
+        google_analytics_id = settings.GA_ID
+    flatpages = FlatPage.objects.all()
+    if len(flatpages) != 0:
+        help_url = flatpages[0].content
+    else:
+        help_url = "https://sites.google.com/umich.edu/my-learning-analytics-help/home"
+
+    myla_globals = {
+        "username" : username,
+        "is_superuser": is_superuser,
+        "user_courses_info": user_courses_info,
+        "login": login_url,
+        "logout": logout_url,
+        "google_analytics_id": google_analytics_id,
+        "help_url": help_url
+    }
+
+    logger.info(myla_globals)
+    myla_globals_json = json.dumps(myla_globals)
+    logger.info(myla_globals_json)
+    return render(request, 'frontend/index.html', context={'myla_globals': myla_globals_json})
 
 
 @permission_required('dashboard.get_course_template',
@@ -732,9 +770,7 @@ def logout(request):
 
 
 def courses_enabled(request):
-    """ Returns json for all courses we currntly support and are enabled
-
-    """
+    """ Returns json for all courses we currently support and are enabled """
     
     if COURSES_ENABLED:
         data = {}


### PR DESCRIPTION
This PR moves the construction of the `myla_globals` object from the `base.html` template to the `get_home_template` function view of `views.py` in order to fix a bug involving improper handling of apostrophes and streamline the appearance of `base.html`. Some other changes were made to simplify or clarify the process of generating a list of courses a user is enrolled in. More details will be forthcoming. The PR aims to resolve #779.

1) The majority of this PR is focused on moving the code and logic constructing a `myla_globals` dictionary or object from `base.html` to the `get_home_template` view. The dictionary can be constructed within the function view, serialized to a JSON string via `json.dumps`, and then passed via `render`'s `context` parameter to the template (see [this StackOverflow page](https://stackoverflow.com/questions/31151229/django-passing-json-from-view-to-template) and [the Django documentation](https://docs.djangoproject.com/en/2.2/topics/http/shortcuts/#render) for reference). Once available to the template, we can initialize the variable within the `script` element, using the `safe` template to ensure the object is passed as is to the React frontend. JavaScript will then see the JSON string as an object, even without calling `JSON.parse`.

2) As part of the process in (1), I updated the `get_user_courses_info` function in `db_utils.py` to return a dictionary of a student's related courses rather than JSON, so it could be more straightforwardly incorporated and nested within `myla_globals`. I believe the change also enabled me to remove some conditional logic from the frontend's `App.js`, since the property's value now is always a list or array (even if it's empty). Additionally, I changed the name of `get_user_courses_info`'s parameter, since `username` communicated a string better to me than `user_id` (which I initially thought was an ID number). I also added some newlines to `db_utils.py` to make the formatting consistent.

3) Because the `get_home_template` view now calls `get_user_courses_info` directly, I removed the `current_user_courses_info` context processor and a reference to it in `settings.py` (the processor is not used elsewhere).

3) Lastly, I changed the variable name of `enrolledCourses` to `relatedCourses` in the frontend, since "enrolled" seemed to be describing the courses, which seemed confusing; "related" seemed to be more clearly bi-directional.