### PR TITLE
#788 security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends netcat vim-tiny jq python3-dev xmlsec1 cron && \
+    apt-get upgrade -y && \
     apt-get clean -y && \
     pip install -r requirements.txt
 


### PR DESCRIPTION
Fixes #788 
It looks likes these packages are pulled out from this image [`python:3.6`](https://github.com/docker-library/python/blob/22b2cebaaee699c43f4eb70c732be92ad4bf098e/3.6/buster/Dockerfile) and no update on that base image with security fixes. 
So doing the `apt-get upgrade -y` pulled in the latest version of those packages.
Build Output pulling the latest version:
```
The following packages will be upgraded:
  file libfribidi0 libmagic-mgc libmagic1
4 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 490 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 http://security.debian.org/debian-security buster/updates/main amd64 file amd64 1:5.35-4+deb10u1 [66.4 kB]
Get:2 http://security.debian.org/debian-security buster/updates/main amd64 libmagic1 amd64 1:5.35-4+deb10u1 [117 kB]
Get:3 http://security.debian.org/debian-security buster/updates/main amd64 libmagic-mgc amd64 1:5.35-4+deb10u1 [242 kB]
Get:4 http://security.debian.org/debian-security buster/updates/main amd64 libfribidi0 amd64 1.0.5-3.1+deb10u1 [63.7 kB]
```
Test by going into container like below:
```
root@8c439df43e9c:/code# apt list file  -a
Listing... Done
file/stable,now 1:5.35-4+deb10u1 amd64 [installed]
file/stable 1:5.35-4 amd64

root@8c439df43e9c:/code# apt list libmagic1  -a
Listing... Done
libmagic1/stable,now 1:5.35-4+deb10u1 amd64 [installed,automatic]
libmagic1/stable 1:5.35-4 amd64

root@8c439df43e9c:/code# apt list libmagic-mgc  -a
Listing... Done
libmagic-mgc/stable,now 1:5.35-4+deb10u1 amd64 [installed,automatic]
libmagic-mgc/stable 1:5.35-4 amd64
```

