### PR TITLE
updating node to version 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build react components for production mode
-FROM node:11.10-alpine AS node-webpack
+FROM node:12-alpine AS node-webpack
 WORKDIR /usr/src/app
 
 # NOTE: package.json and webpack.config.js not likely to change between dev builds
@@ -19,7 +19,7 @@ RUN apk --update add tar && \
     rm -rf /usr/src/app/assets/src
 
 # build node libraries for production mode
-FROM node:11.10-alpine AS node-prod-deps
+FROM node:12-alpine AS node-prod-deps
 
 COPY --from=node-webpack /usr/src/app /usr/src/app
 RUN npm prune --production && \

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "jest-resolve": "24.5.0",
     "js-cookie": "~2.2.0",
     "mini-css-extract-plugin": "0.5.0",
-    "node-sass": "~4.11.0",
+    "node-sass": "~4.12.0",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.4.1",
     "popper.js": "~1.14.7",


### PR DESCRIPTION
Fixes #790 
I just need to update the `node-sass` dependency to [14.12](https://github.com/sass/node-sass#supported-nodejs-versions-vary-by-release-please-consult-the-releases-page-below-is-a-quick-guide-for-minimum-support) as that is the support version for Node 12. Webpack-watcher behavior doesn't seem to be affected. I put this build on [Dev](https://dev-myla.tl.it.umich.edu/) instance seems to work fine.