### PR TITLE
Simplified API Format for Grade Distribution View (#707)

### DIFF
--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -59,19 +59,19 @@ function GradeDistribution (props) {
   if (gradeError) return (<WarningBanner />)
 
   const BuildGradeView = () => {
-    const grades = gradeData.map(x => x.current_grade)
+    const grades = gradeData.grades
 
     const tableRows = [
-      ['Average grade', <strong key={0}>{gradeData[0].grade_avg}%</strong>],
-      ['Median grade', <strong key={1}>{gradeData[0].median_grade}%</strong>],
-      ['Number of students', <strong key={2}>{gradeData[0].tot_students}</strong>],
+      ['Average grade', <strong key={0}>{gradeData.summary.grade_avg}%</strong>],
+      ['Median grade', <strong key={1}>{gradeData.summary.median_grade}%</strong>],
+      ['Number of students', <strong key={2}>{gradeData.summary.tot_students}</strong>],
       !user.admin && showGrade
         ? ([
           'My grade',
           <strong key={0}>
             {
-              gradeData[0].current_user_grade
-                ? `${roundToOneDecimal(gradeData[0].current_user_grade)}%`
+              gradeData.summary.current_user_grade
+                ? `${roundToOneDecimal(gradeData.summary.current_user_grade)}%`
                 : 'There are no grades yet for you in this course'
             }
           </strong>
@@ -108,10 +108,10 @@ function GradeDistribution (props) {
             aspectRatio={0.3}
             xAxisLabel='Grade %'
             yAxisLabel='Number of Students'
-            myGrade={showGrade ? gradeData[0].current_user_grade : null}
-            maxGrade={gradeData[0].graph_upper_limit}
-            showNumberOnBars={gradeData[0].show_number_on_bars}
-            showDashedLine={gradeData[0].show_dash_line}
+            myGrade={showGrade ? gradeData.summary.current_user_grade : null}
+            maxGrade={gradeData.summary.graph_upper_limit}
+            showNumberOnBars={gradeData.summary.show_number_on_bars}
+            showDashedLine={gradeData.summary.show_dash_line}
           />
         </Grid>
       </Grid>

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -350,12 +350,17 @@ def grade_distribution(request, course_id=0):
     if df.empty or df['current_grade'].isnull().all():
         return HttpResponse(json.dumps({}), content_type='application/json')
 
-    df['tot_students'] = df.shape[0]
+    result = {}
+    result['summary'] = {}
+    result['summary']['current_user_grade'] = df['current_user_grade'].values[0]
+    result['summary']['tot_students'] = df.shape[0]
     df = df[df['current_grade'].notnull()]
     df['current_grade'] = df['current_grade'].astype(float)
-    df['grade_avg'] = df['current_grade'].mean().round(2)
-    df['median_grade'] = df['current_grade'].median().round(2)
-    df['show_number_on_bars'] = df['show_number_on_bars'].apply(lambda x: True if x == 1 else False)
+    result['summary']['grade_avg'] = df['current_grade'].mean().round(2)
+    result['summary']['median_grade'] = df['current_grade'].median().round(2)
+    result['summary']['show_number_on_bars'] = False
+    if df['show_number_on_bars'].values[0] == 1:
+        result['summary']['show_number_on_bar'] = True
 
     df.sort_values(by=['current_grade'], inplace=True)
     df.reset_index(drop=True, inplace=True)
@@ -365,14 +370,15 @@ def grade_distribution(request, course_id=0):
     if BinningGrade is not None and not BinningGrade.binning_all:
         df['current_grade'] = df['current_grade'].replace(df['current_grade'].head(BinningGrade.index),
                                                       BinningGrade.value)
-    df['show_dash_line'] = show_dashed_line(df['current_grade'].iloc[0], BinningGrade)
-
+    result['summary']['show_dash_line'] = show_dashed_line(df['current_grade'].iloc[0], BinningGrade)
+    
     if df[df['current_grade'] > 100.0].shape[0] > 0:
-        df['graph_upper_limit'] = int((5 * round(float(df['current_grade'].max()) / 5) + 5))
+        result['summary']['graph_upper_limit'] = int((5 * round(float(df['current_grade'].max()) / 5) + 5))
     else:
         df['current_grade'] = df['current_grade'].apply(lambda x: 99.99 if x == 100.00 else x)
-        df['graph_upper_limit'] = 100
+        result['summary']['graph_upper_limit'] = 100
 
+    result['grades'] = df['current_grade'].values.tolist()
 
     # json for eventlog
     data = {
@@ -381,7 +387,7 @@ def grade_distribution(request, course_id=0):
     }
     eventlog(request.user, EventLogTypes.EVENT_VIEW_GRADE_DISTRIBUTION.value, extra=data)
 
-    return HttpResponse(df.to_json(orient='records'))
+    return HttpResponse(json.dumps(result))
 
 
 @permission_required('dashboard.update_user_default_selection_for_views',

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -350,17 +350,17 @@ def grade_distribution(request, course_id=0):
     if df.empty or df['current_grade'].isnull().all():
         return HttpResponse(json.dumps({}), content_type='application/json')
 
-    result = {}
-    result['summary'] = {}
-    result['summary']['current_user_grade'] = df['current_user_grade'].values[0]
-    result['summary']['tot_students'] = df.shape[0]
+    grade_view_data = dict()
+    summary = dict()
+    summary['current_user_grade'] = df['current_user_grade'].values[0]
+    summary['tot_students'] = df.shape[0]
     df = df[df['current_grade'].notnull()]
     df['current_grade'] = df['current_grade'].astype(float)
-    result['summary']['grade_avg'] = df['current_grade'].mean().round(2)
-    result['summary']['median_grade'] = df['current_grade'].median().round(2)
-    result['summary']['show_number_on_bars'] = False
+    summary['grade_avg'] = df['current_grade'].mean().round(2)
+    summary['median_grade'] = df['current_grade'].median().round(2)
+    summary['show_number_on_bars'] = False
     if df['show_number_on_bars'].values[0] == 1:
-        result['summary']['show_number_on_bar'] = True
+        summary['show_number_on_bar'] = True
 
     df.sort_values(by=['current_grade'], inplace=True)
     df.reset_index(drop=True, inplace=True)
@@ -370,15 +370,16 @@ def grade_distribution(request, course_id=0):
     if BinningGrade is not None and not BinningGrade.binning_all:
         df['current_grade'] = df['current_grade'].replace(df['current_grade'].head(BinningGrade.index),
                                                       BinningGrade.value)
-    result['summary']['show_dash_line'] = show_dashed_line(df['current_grade'].iloc[0], BinningGrade)
+    summary['show_dash_line'] = show_dashed_line(df['current_grade'].iloc[0], BinningGrade)
     
     if df[df['current_grade'] > 100.0].shape[0] > 0:
-        result['summary']['graph_upper_limit'] = int((5 * round(float(df['current_grade'].max()) / 5) + 5))
+        summary['graph_upper_limit'] = int((5 * round(float(df['current_grade'].max()) / 5) + 5))
     else:
         df['current_grade'] = df['current_grade'].apply(lambda x: 99.99 if x == 100.00 else x)
-        result['summary']['graph_upper_limit'] = 100
+        summary['graph_upper_limit'] = 100
 
-    result['grades'] = df['current_grade'].values.tolist()
+    grade_view_data['summary'] = summary
+    grade_view_data['grades'] = df['current_grade'].values.tolist()
 
     # json for eventlog
     data = {
@@ -387,7 +388,7 @@ def grade_distribution(request, course_id=0):
     }
     eventlog(request.user, EventLogTypes.EVENT_VIEW_GRADE_DISTRIBUTION.value, extra=data)
 
-    return HttpResponse(json.dumps(result))
+    return HttpResponse(json.dumps(grade_view_data))
 
 
 @permission_required('dashboard.update_user_default_selection_for_views',


### PR DESCRIPTION
The grade distribution API used to send a full dataframe. This PR changes it so that a simplified JSON string is sent instead of a full dataframe. This JSON string follows this format:
```
{ 
   "summary":{ 
      "current_user_grade": XX.X,
      "tot_students": XX,
      "grade_avg": XX.X,
      "median_grade": XX.X,
      "show_number_on_bars": false,
      "show_dash_line": true,
      "graph_upper_limit": XX.X
   },
   "grades":[XX.X, XX.X, ...]
}
```
This PR addresses and closes issue #707. 