### PR TITLE
Update snackbar visualization time for issue #806

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ You may also optionally place the json settings directly into the `ENV_JSON` env
     username: root
     password: root
     ```
-1. As you are now logged in as `root`, there are no courses listed. Go through the latest SQL file you downloaded from the link in the setup and search for the line "INSERT INTO `course` VALUES". You can find the course_id in the second column of the tuples. And then nagivate to http://localhost:5001/courses/{course_id} with the course_id you found. (For example, with SQL file myla_test_data_2019_10_16.sql, on line 323, you can find course_id = 235420 or course_id = 362855. And then nagivate to http://localhost:5001/courses/235420 or http://localhost:5001/courses/362855 and you can view the course page as an admin.)
+1. As you are now logged in as `root`, there are no courses listed. Next 3 steps will help you view a sample course.
+1. Connect to MySQL database.
+    ```
+    Host: 127.0.0.1
+    Username: student_dashboard_user
+    Password: student_dashboard_pw
+    Database: student_dashboard
+    Port: 5306
+    ```
+1. Navigate to `course` table and select canvas_id `canvas_id`("SELECT canvas_id From course"), which will be used in the next step.
+1. Nagivate to http://localhost:5001/courses/{canvas_id} with the canvas_id you found. (For example, with SQL file myla_test_data_2019_10_16.sql loaded in, nagivate to http://localhost:5001/courses/235420 or http://localhost:5001/courses/362855 and you can view the course page as an admin.) 
 1. To get to the Django admin panel, click on the Avator in the top right, then click `Admin`, or go here: http://localhost:5001/admin.
 
 #### Logging in as a student

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You may also optionally place the json settings directly into the `ENV_JSON` env
     username: root
     password: root
     ```
-1. As you are now logged in as `root`, there are no courses listed. 
+1. As you are now logged in as `root`, there are no courses listed. Go through the latest SQL file you downloaded from the link in the setup and search for the line "INSERT INTO `course` VALUES". You can find the course_id in the second column of the tuples. And then nagivate to http://localhost:5001/courses/{course_id} with the course_id you found. (For example, with SQL file myla_test_data_2019_10_16.sql, on line 323, you can find course_id = 235420 or course_id = 362855. And then nagivate to http://localhost:5001/courses/235420 or http://localhost:5001/courses/362855 and you can view the course page as an admin.)
 1. To get to the Django admin panel, click on the Avator in the top right, then click `Admin`, or go here: http://localhost:5001/admin.
 
 #### Logging in as a student

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You may also optionally place the json settings directly into the `ENV_JSON` env
     username: root
     password: root
     ```
-1. As you are now logged in as `root`, there are no courses listed. Navigate to http://localhost:5001/courses/231768 or http://localhost:5001/courses/430174 to view a sample course as a superuser.
+1. As you are now logged in as `root`, there are no courses listed. 
 1. To get to the Django admin panel, click on the Avator in the top right, then click `Admin`, or go here: http://localhost:5001/admin.
 
 #### Logging in as a student

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -4,7 +4,7 @@ import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
 import Slide from '@material-ui/core/Slide'
 
-function SlideTransition(props) {
+function SlideTransition (props) {
   return <Slide {...props} direction='up' />
 }
 
@@ -39,12 +39,12 @@ function UserSettingSnackbar (props) {
         horizontal: 'left'
       }}
       ContentProps={{
-        'role': 'alertdialog',
+        role: 'alertdialog'
       }}
       open={savedSnackbarOpen}
       autoHideDuration={snackbarDuration}
       TransitionComponent={SlideTransition}
-      transitionDuration={{exit: 400, enter: 400}}
+      transitionDuration={{ exit: 400, enter: 400 }}
       onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
       action={[

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -44,7 +44,7 @@ function UserSettingSnackbar (props) {
       // Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus
       // set for 800ms temporily for better view
       TransitionComponent={SlideTransition}
-      transitionDuration={{exit: 800, enter: 800}}
+      transitionDuration={{exit: 400, enter: 400}}
       onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
       // should not require users to close a Snackbar if the role is set to alert

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -17,7 +17,7 @@ function UserSettingSnackbar (props) {
     failureMessage = 'Setting not saved.'
   } = props
 
-  // const [savedSnackbarOpen, setSavedSnackbarOpen] = useState(false)
+  const [savedSnackbarOpen, setSavedSnackbarOpen] = useState(false)
   const [snackbarMessage, setSnackbarMessage] = useState('')
 
   useEffect(() => {
@@ -27,7 +27,7 @@ function UserSettingSnackbar (props) {
       } else {
         setSnackbarMessage(failureMessage)
       }
-      // setSavedSnackbarOpen(true)
+      setSavedSnackbarOpen(true)
     }
   }, [saved])
 
@@ -38,26 +38,23 @@ function UserSettingSnackbar (props) {
         horizontal: 'left'
       }}
       open={savedSnackbarOpen}
-      role="alert"
       // show for 50ms for each of the characters in the message
       autoHideDuration={"{snackbarMessage}".length * 50}
       // Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus
-      // set for 800ms temporily for better view
       TransitionComponent={SlideTransition}
-      transitionDuration={{exit: 800, enter: 800}}
-      // onClose={() => setSavedSnackbarOpen(false)}
+      transitionDuration={{exit: 400, enter: 800}}
+      onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
-      // should not require users to close a Snackbar if the role is set to alert
-      // action={[
-      //   <IconButton
-      //     key='close'
-      //     aria-label='close'
-      //     color='inherit'
-      //     onClick={() => setSavedSnackbarOpen(false)}
-      //   >
-      //     <CloseIcon />
-      //   </IconButton>
-      // ]}
+      action={[
+        <IconButton
+          key='close'
+          aria-label='close'
+          color='inherit'
+          onClick={() => setSavedSnackbarOpen(false)}
+        >
+          <CloseIcon />
+        </IconButton>
+      ]}
     />
   )
 }

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -37,6 +37,10 @@ function UserSettingSnackbar (props) {
         vertical: 'bottom',
         horizontal: 'left'
       }}
+      // If a Snackbar requires focus to close it, then content authors should use the role of alertdialog.
+      ContentProps={{
+        'role': 'alertdialog',
+      }}
       open={savedSnackbarOpen}
       // show for 200ms for each of the characters in the message
       autoHideDuration={"{snackbarMessage}".length * 200}

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -2,11 +2,10 @@ import React, { useState, useEffect } from 'react'
 import Snackbar from '@material-ui/core/Snackbar'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
-import Fade from '@material-ui/core/Fade';
-import Slide from '@material-ui/core/Slide';
+import Slide from '@material-ui/core/Slide'
 
 function SlideTransition(props) {
-  return <Slide {...props} direction="up" />;
+  return <Slide {...props} direction='up' />
 }
 
 function UserSettingSnackbar (props) {
@@ -31,20 +30,19 @@ function UserSettingSnackbar (props) {
     }
   }, [saved])
 
+  const snackbarDuration = Math.max(snackbarMessage.length * 200, 4000)
+  
   return (
     <Snackbar
       anchorOrigin={{
         vertical: 'bottom',
         horizontal: 'left'
       }}
-      // If a Snackbar requires focus to close it, then content authors should use the role of alertdialog.
       ContentProps={{
         'role': 'alertdialog',
       }}
       open={savedSnackbarOpen}
-      // show for 200ms for each of the characters in the message
-      autoHideDuration={"{snackbarMessage}".length * 200}
-      // Fade in (or slide in) for 400ms for saccade time for the eye to refocus
+      autoHideDuration={snackbarDuration}
       TransitionComponent={SlideTransition}
       transitionDuration={{exit: 400, enter: 400}}
       onClose={() => setSavedSnackbarOpen(false)}

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -17,7 +17,7 @@ function UserSettingSnackbar (props) {
     failureMessage = 'Setting not saved.'
   } = props
 
-  const [savedSnackbarOpen, setSavedSnackbarOpen] = useState(false)
+  // const [savedSnackbarOpen, setSavedSnackbarOpen] = useState(false)
   const [snackbarMessage, setSnackbarMessage] = useState('')
 
   useEffect(() => {
@@ -27,7 +27,7 @@ function UserSettingSnackbar (props) {
       } else {
         setSnackbarMessage(failureMessage)
       }
-      setSavedSnackbarOpen(true)
+      // setSavedSnackbarOpen(true)
     }
   }, [saved])
 
@@ -38,23 +38,26 @@ function UserSettingSnackbar (props) {
         horizontal: 'left'
       }}
       open={savedSnackbarOpen}
+      role="alert"
       // show for 50ms for each of the characters in the message
       autoHideDuration={"{snackbarMessage}".length * 50}
       // Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus
+      // set for 800ms temporily for better view
       TransitionComponent={SlideTransition}
-      transitionDuration={{exit: 400, enter: 800}}
-      onClose={() => setSavedSnackbarOpen(false)}
+      transitionDuration={{exit: 800, enter: 800}}
+      // onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
-      action={[
-        <IconButton
-          key='close'
-          aria-label='close'
-          color='inherit'
-          onClick={() => setSavedSnackbarOpen(false)}
-        >
-          <CloseIcon />
-        </IconButton>
-      ]}
+      // should not require users to close a Snackbar if the role is set to alert
+      // action={[
+      //   <IconButton
+      //     key='close'
+      //     aria-label='close'
+      //     color='inherit'
+      //     onClick={() => setSavedSnackbarOpen(false)}
+      //   >
+      //     <CloseIcon />
+      //   </IconButton>
+      // ]}
     />
   )
 }

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -38,23 +38,26 @@ function UserSettingSnackbar (props) {
         horizontal: 'left'
       }}
       open={savedSnackbarOpen}
+      role="alert"
       // show for 50ms for each of the characters in the message
       autoHideDuration={"{snackbarMessage}".length * 50}
       // Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus
+      // set for 800ms temporily for better view
       TransitionComponent={SlideTransition}
-      transitionDuration={{exit: 400, enter: 800}}
+      transitionDuration={{exit: 800, enter: 800}}
       onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
-      action={[
-        <IconButton
-          key='close'
-          aria-label='close'
-          color='inherit'
-          onClick={() => setSavedSnackbarOpen(false)}
-        >
-          <CloseIcon />
-        </IconButton>
-      ]}
+      // should not require users to close a Snackbar if the role is set to alert
+      // action={[
+      //   <IconButton
+      //     key='close'
+      //     aria-label='close'
+      //     color='inherit'
+      //     onClick={() => setSavedSnackbarOpen(false)}
+      //   >
+      //     <CloseIcon />
+      //   </IconButton>
+      // ]}
     />
   )
 }

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -2,6 +2,12 @@ import React, { useState, useEffect } from 'react'
 import Snackbar from '@material-ui/core/Snackbar'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
+import Fade from '@material-ui/core/Fade';
+import Slide from '@material-ui/core/Slide';
+
+function SlideTransition(props) {
+  return <Slide {...props} direction="up" />;
+}
 
 function UserSettingSnackbar (props) {
   const {
@@ -32,7 +38,11 @@ function UserSettingSnackbar (props) {
         horizontal: 'left'
       }}
       open={savedSnackbarOpen}
-      autoHideDuration={3000}
+      // show for 50ms for each of the characters in the message
+      autoHideDuration={"{snackbarMessage}".length * 50}
+      // Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus
+      TransitionComponent={SlideTransition}
+      transitionDuration={{exit: 400, enter: 800}}
       onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
       action={[

--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -38,26 +38,23 @@ function UserSettingSnackbar (props) {
         horizontal: 'left'
       }}
       open={savedSnackbarOpen}
-      role="alert"
-      // show for 50ms for each of the characters in the message
-      autoHideDuration={"{snackbarMessage}".length * 50}
-      // Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus
-      // set for 800ms temporily for better view
+      // show for 200ms for each of the characters in the message
+      autoHideDuration={"{snackbarMessage}".length * 200}
+      // Fade in (or slide in) for 400ms for saccade time for the eye to refocus
       TransitionComponent={SlideTransition}
       transitionDuration={{exit: 400, enter: 400}}
       onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
-      // should not require users to close a Snackbar if the role is set to alert
-      // action={[
-      //   <IconButton
-      //     key='close'
-      //     aria-label='close'
-      //     color='inherit'
-      //     onClick={() => setSavedSnackbarOpen(false)}
-      //   >
-      //     <CloseIcon />
-      //   </IconButton>
-      // ]}
+      action={[
+        <IconButton
+          key='close'
+          aria-label='close'
+          color='inherit'
+          onClick={() => setSavedSnackbarOpen(false)}
+        >
+          <CloseIcon />
+        </IconButton>
+      ]}
     />
   )
 }


### PR DESCRIPTION
Change according to the suggestion : "Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus, then show for 50ms for each of the characters in the message." for issue #806. Also added role=alert