### PR TITLE
Supplies better error message if the course doesn't exist (#670)

### DIFF
--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -16,8 +16,8 @@ function Course (props) {
   const [loaded, error, courseInfo] = useCourseInfo(courseId)
   const [sideDrawerState, setSideDrawerState] = useState(false)
 
-  if (error.message === "Not Found") return (<WarningBanner>Error: Not Found. Course {courseId} does not exist.</WarningBanner>)
-  else if (error.message === "Forbidden") return (<WarningBanner>Error: Forbidden. You do not have access to course {courseId}.</WarningBanner>)
+  if (error.message === "Not Found") return (<WarningBanner>Course {courseId} does not exist.</WarningBanner>)
+  else if (error.message === "Forbidden") return (<WarningBanner>You do not have access to course {courseId}.</WarningBanner>)
   else if (error) return (<WarningBanner />) 
   if (loaded && isObjectEmpty(courseInfo)) return (<WarningBanner>My Learning Analytics is not enabled for this course.</WarningBanner>)
 

--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -16,7 +16,8 @@ function Course (props) {
   const [loaded, error, courseInfo] = useCourseInfo(courseId)
   const [sideDrawerState, setSideDrawerState] = useState(false)
 
-  if (error) return (<WarningBanner />)
+  if (error.message === "Not Found") return (<WarningBanner>Error: Not Found. Course {courseId} does not exist.</WarningBanner>)
+  if (error.message === "Forbidden") return (<WarningBanner>Error: Forbidden. You do not have access to course {courseId}.</WarningBanner>)
   if (loaded && isObjectEmpty(courseInfo)) return (<WarningBanner>My Learning Analytics is not enabled for this course.</WarningBanner>)
 
   return (

--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -17,7 +17,8 @@ function Course (props) {
   const [sideDrawerState, setSideDrawerState] = useState(false)
 
   if (error.message === "Not Found") return (<WarningBanner>Error: Not Found. Course {courseId} does not exist.</WarningBanner>)
-  if (error.message === "Forbidden") return (<WarningBanner>Error: Forbidden. You do not have access to course {courseId}.</WarningBanner>)
+  else if (error.message === "Forbidden") return (<WarningBanner>Error: Forbidden. You do not have access to course {courseId}.</WarningBanner>)
+  else if (error) return (<WarningBanner />) 
   if (loaded && isObjectEmpty(courseInfo)) return (<WarningBanner>My Learning Analytics is not enabled for this course.</WarningBanner>)
 
   return (


### PR DESCRIPTION
Hi, me and @luctiger have been working on this bug fix so that we could make an open source contribution for our 481 class. The proposed change makes it so that a user will see helpful error messages if they try to access a course that does not exist (404) or a course that they do not have permission to view (403). A different message is displayed for each error. Here are the error messages:
![404-Not_Found](https://user-images.githubusercontent.com/46611530/70102964-bd049e00-1607-11ea-919d-c88569a52688.png)
![403-Forbidden](https://user-images.githubusercontent.com/46611530/70102971-c2fa7f00-1607-11ea-8adf-6be22fcad601.png)

