### PR TITLE
Update snackbar visualization time for issue #806 from branch issue-806-fix-snackbar-duration

### DIFF
--- a/assets/src/components/UserSettingSnackbar.js
+++ b/assets/src/components/UserSettingSnackbar.js
@@ -2,6 +2,11 @@ import React, { useState, useEffect } from 'react'
 import Snackbar from '@material-ui/core/Snackbar'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
+import Slide from '@material-ui/core/Slide'
+
+function SlideTransition (props) {
+  return <Slide {...props} direction='up' />
+}
 
 function UserSettingSnackbar (props) {
   const {
@@ -25,14 +30,21 @@ function UserSettingSnackbar (props) {
     }
   }, [saved])
 
+  const snackbarDuration = Math.max(snackbarMessage.length * 200, 4000)
+  
   return (
     <Snackbar
       anchorOrigin={{
         vertical: 'bottom',
         horizontal: 'left'
       }}
+      ContentProps={{
+        role: 'alertdialog'
+      }}
       open={savedSnackbarOpen}
-      autoHideDuration={3000}
+      autoHideDuration={snackbarDuration}
+      TransitionComponent={SlideTransition}
+      transitionDuration={{ exit: 400, enter: 400 }}
       onClose={() => setSavedSnackbarOpen(false)}
       message={<span>{snackbarMessage}</span>}
       action={[
@@ -50,3 +62,4 @@ function UserSettingSnackbar (props) {
 }
 
 export default UserSettingSnackbar
+


### PR DESCRIPTION
Advised from PR #815 

Changed according to the suggestion : "Fade in (or slide in) for 200-400ms for saccade time for the eye to refocus, then show for 200ms for each of the characters in the message." for issue #806. 
Also give the duration time a minimum value 4000ms.
Also added role=alertdialog.