### PR TITLE
Fix typo in grade_distribution view (#851)

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -326,7 +326,7 @@ def grade_distribution(request, course_id=0):
     summary['median_grade'] = df['current_grade'].median().round(2)
     summary['show_number_on_bars'] = False
     if df['show_number_on_bars'].values[0] == 1:
-        summary['show_number_on_bar'] = True
+        summary['show_number_on_bars'] = True
 
     df.sort_values(by=['current_grade'], inplace=True)
     df.reset_index(drop=True, inplace=True)


### PR DESCRIPTION
This PR makes a small change to the `grade_distribution` view in `views.py` to fix a bug that was causing grade counts not to show on histogram bars when "Show Grade Counts" was checked in the Django admin. I fixed a conditional statement that was assigning `True` as the value associated with a key `show_number_on_bar` so that instead it updates an existing property "show_number_on_bars" that was initialized as `False`. The PR aims tor resolve #851.