### PR TITLE
Modify palette colors and visualization text colors to improve contrast (#748, #805)

### DIFF
--- a/assets/src/components/d3/createProgressBar.js
+++ b/assets/src/components/d3/createProgressBar.js
@@ -86,6 +86,7 @@ function createProgressBar ({ data, width, height, domElement, tip }) {
       return displayable
     })
     .style('font-size', '0.875rem')
+    .style('fill', d => d.graded ? 'white' : 'black')
     .style('text-overflow', 'ellipsis')
 
   const xAxis = g => g

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -137,6 +137,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('dx', -10)
       .attr('dy', '.35em')
       .style('font-size', 10)
+      .style('fill', d => d.self_access_count > 0 ? 'white' : 'black')
       .attr('text-anchor', 'end')
       .text(d => (
         ((mainYScale(d.resource_name) + mainYScale.bandwidth() / 2) < miniHeight) &&

--- a/assets/src/defaultPalette.js
+++ b/assets/src/defaultPalette.js
@@ -2,17 +2,17 @@ const defaultPalette = {
   /* The 'primary' color is used for structural components like the AppBar and SelectCard.
      Different institutions using this application are encouraged to modify the provided value. */
   primary: {
-    main: '#40658F'
+    main: '#00274C'
   },
   /* The 'secondary' color is used currently to indicate a positive, completed, viewed, or selected state.
      This value was arrived at through research and design work; use caution when modifying. */
   secondary: {
-    main: '#4682B4'
+    main: '#2C6496'
   },
   /* The 'negative' color is used currently to indicate a negative, un-completed, un-viewed, or un-selected state.
      This value was arrived at through research and design work; use caution when modifying. */
   negative: {
-    main: '#E1E1E1'
+    main: '#B5B5B5'
   }
 }
 

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -10,7 +10,7 @@
         "localhost"
     ],
     "/* # The hex value to be used in the front end for the primary color of the palette and theme": "*/",
-    "PRIMARY_UI_COLOR": "#40658F",
+    "PRIMARY_UI_COLOR": "#00274C",
     "/* Configuration of CSP see https://django-csp.readthedocs.io/en/latest/configuration.html": "*/",
     "/* To enable this at all you must set have the CSP key set": "*/",
     "/* and REPORT_ONLY should be be false, otherwise it will just console Warn": "*/",


### PR DESCRIPTION
This PR makes some changes to the color palette used by the front end's `siteTheme`, based on work done by @jennlove-um. The  default `primary` color  was changed to better match UM's integration with Canvas (note that the `primary` after PR #845 is configurable through `env.json`). The `secondary` and `negative` colors were modified to maximize contrast between them (which is still below where we'd like it to be, at 3.03) while also maintaining adequate contrast between the `negative` gray and the white background. I also modified the `d3` components for the visualizations in Resources Accessed and (the old) Assignment Planning so that text on bars is white when the background color is `secondary` (blue) and black when the background color is `negative` (gray). This PR aims to resolve issues #748 and #805.