### PR TITLE
Re-color resource links for consistency across browsers

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.css
+++ b/assets/src/components/d3/createResourceAccessChart.css
@@ -26,7 +26,3 @@
     top: 100%;
     left: 0;
   }
-
-  .resourceIcon {
-    color: #0000EE
-  }

--- a/assets/src/components/d3/createResourceAccessChart.css
+++ b/assets/src/components/d3/createResourceAccessChart.css
@@ -26,3 +26,7 @@
     top: 100%;
     left: 0;
   }
+
+  .resourceIcon {
+    color: #0000EE
+  }

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -367,7 +367,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('text-anchor', 'start')
     a.node().appendChild(this)
 
-    const icon = d.split('|')[2]
+    let icon = d.split('|')[2]
     d3.select(this).insert('foreignObject')
       .attr('x', -180)
       .attr('y', -6)

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -365,17 +365,17 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('xlink:target', '_blank')
       .attr('xlink:href', link)
       .attr('text-anchor', 'start')
-      .attr('fill', null)
     a.node().appendChild(this)
 
-    const iconClasses = d.split('|')[2]
+    const icon = d.split('|')[2]
     d3.select(this).insert('foreignObject')
       .attr('x', -180)
       .attr('y', -6)
       .attr('width', 32)
       .attr('height', 32)
+      .attr('color', '#0000EE')
       .append('xhtml:i')
-      .attr('class', 'resourceIcon ' + iconClasses)
+      .attr('class', icon)
   })
 }
 

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -210,9 +210,10 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
         : 0.5
       )
 
-    // Update the label size
+    // Update the resource labels
     d3.selectAll('.axis--y text')
       .attr('x', -150)
+      .attr('fill', '#0000EE')
       .style('font-size', textScale(selected.length))
 
     update()
@@ -364,16 +365,18 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('xlink:target', '_blank')
       .attr('xlink:href', link)
       .attr('text-anchor', 'start')
+      .attr('fill', null)
     a.node().appendChild(this)
 
-    let icon = d.split('|')[2]
+    const iconClasses = d.split('|')[2]
     d3.select(this).insert('foreignObject')
       .attr('x', -180)
       .attr('y', -6)
       .attr('width', 32)
       .attr('height', 32)
       .append('xhtml:i')
-      .attr('class', icon)
+      .attr('class', 'resourceIcon ' + iconClasses)
   })
 }
+
 export default createResourceAccessChart


### PR DESCRIPTION
This PR changes the d3 component `createResourceAccessChart` so that the resource labels and icons are a standard link blue (#0000EE). Previously, when these were uncolored, we observed inconsistencies between how browsers colored these elements (Firefox treating them as links, Chrome just coloring them gray). This PR aims to resolve issue #830. Thanks to @vjcao for creating the issue and giving me tips on resolving it.