### PR TITLE
Replace not None check with pd.notna in update_datetime_field

### DIFF
--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -91,7 +91,7 @@ def update_datetime_field(course_obj, course_field_name, warehouse_dataframe, wa
         logger.info(f"Update of {course_field_name} skipped; existing value was found.")
     else:
         warehouse_field_value = warehouse_dataframe[warehouse_field_name].iloc[0]
-        if not pd.isnull(warehouse_field_value):
+        if pd.notna(warehouse_field_value):
             warehouse_field_value = warehouse_field_value.replace(tzinfo=pytz.UTC)
             setattr(course_obj, course_field_name, warehouse_field_value)
             logger.info(f"{course_field_name} for {course_obj.id} has been updated.")

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -91,7 +91,7 @@ def update_datetime_field(course_obj, course_field_name, warehouse_dataframe, wa
         logger.info(f"Update of {course_field_name} skipped; existing value was found.")
     else:
         warehouse_field_value = warehouse_dataframe[warehouse_field_name].iloc[0]
-        if warehouse_field_value is not None:
+        if not pd.isnull(warehouse_field_value):
             warehouse_field_value = warehouse_field_value.replace(tzinfo=pytz.UTC)
             setattr(course_obj, course_field_name, warehouse_field_value)
             logger.info(f"{course_field_name} for {course_obj.id} has been updated.")


### PR DESCRIPTION
This PR fixes an error we were encountering after merging PR #868 that was caused by unexpected conversion of `None` values to `NaT` values when concatenating DataFrames in the `verify_course_ids` method in `cron.py`. The change to the condition in `update_datetime_field`, with the use of `pd.isnull`, should handle cases of `None` and `NaT`. The PR aims to resolve issue #870.