### PR TITLE
Correct version ranges in requirements.txt (#897)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 gunicorn>=19.9.0,<19.9.99
 
 # We're waiting on Django 3 until it's further into the lifecycle.
-Django>=2.2.9,<2.2.9.99
-whitenoise>=4.1.4,<4.1.499
+Django>=2.2.9,<2.2.99
+whitenoise>=4.1.4,<4.1.99
 
 django-registration>=3.0,<3.0.99
 django-cron>=0.5.1,<0.5.99
@@ -30,12 +30,12 @@ protobuf>=3.10.0,<3.10.99
 djangosaml2==0.17.2
 pysaml2==4.8.0
 
-SQLAlchemy>=1.3.10,<1.3.199
-psycopg2>=2.8.4,<2.8.499 --no-binary psycopg2
-mysqlclient>=1.4.4,<1.4.499
+SQLAlchemy>=1.3.10,<1.3.99
+psycopg2>=2.8.4,<2.8.99 --no-binary psycopg2
+mysqlclient>=1.4.4,<1.4.99
 google-cloud-bigquery>=1.21.0,<1.21.99
 
-pinax-eventlog>=2.0.3,<2.99
+pinax-eventlog>=2.0.3,<2.0.99
 ptvsd>=4.3.2,<4.3.99
 django-ptvsd-debug==1.0.3
 django-lti-auth==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 gunicorn>=19.9.0,<19.9.99
 
 # We're waiting on Django 3 until it's further into the lifecycle.
-Django>=2.2.9,<2.2.99
+Django>=2.2.10,<2.2.99
 whitenoise>=4.1.4,<4.1.99
 
 django-registration>=3.0,<3.0.99


### PR DESCRIPTION
This PR modifies some version ranges in `requirements.txt` to ensure minor version release updates are allowed for trusted dependencies (specifically, with Django) and that version ranges are normalized (using realistic and consistent patterns). The PR aims to resolve issue #897.

The changes here resulted in only these differences from the test instance (which is built off the `2020.01.x` branch).

```
< Django==2.2.9
---
> Django==2.2.10
35c35
< jsonfield==2.0.2
---
> jsonfield==2.1.1
```