### PR TITLE
Provide unenrolled users with better feedback, add link color to palette (#785)

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -15,6 +15,7 @@ import { siteTheme } from '../../globals'
 
 const accessedResourceColor = siteTheme.palette.secondary.main
 const notAccessedResourceColor = siteTheme.palette.negative.main
+const linkColor = siteTheme.palette.link.main
 const mainMargin = { top: 50, right: 10, bottom: 50, left: 200 }
 
 const toolTip = d3tip().attr('class', 'd3-tip')
@@ -214,7 +215,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     // Update the resource labels
     d3.selectAll('.axis--y text')
       .attr('x', -160)
-      .attr('fill', '#0000EE')
+      .attr('fill', linkColor)
       .style('font-size', textScale(selected.length))
 
     update()
@@ -374,7 +375,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('y', -6)
       .attr('width', 32)
       .attr('height', 32)
-      .attr('color', '#0000EE')
+      .attr('color', linkColor)
       .append('xhtml:i')
       .attr('class', icon)
   })

--- a/assets/src/containers/CourseList.js
+++ b/assets/src/containers/CourseList.js
@@ -1,17 +1,17 @@
 import React, { useState } from 'react'
-import { withStyles } from '@material-ui/core/styles'
-import Grid from '@material-ui/core/Grid'
-import SelectCard from '../components/SelectCard'
-import Typography from '@material-ui/core/Typography'
 import { Link } from 'react-router-dom'
-import Paper from '@material-ui/core/Paper'
+import { withStyles } from '@material-ui/core/styles'
 import AppBar from '@material-ui/core/AppBar'
-import Toolbar from '@material-ui/core/Toolbar'
-import IconButton from '@material-ui/core/IconButton'
 import Avatar from '@material-ui/core/Avatar'
+import Grid from '@material-ui/core/Grid'
+import IconButton from '@material-ui/core/IconButton'
+import MuiLink from '@material-ui/core/Link'
 import Popover from '@material-ui/core/Popover'
+import Toolbar from '@material-ui/core/Toolbar'
+import Typography from '@material-ui/core/Typography'
+import AlertBanner from '../components/AlertBanner'
 import AvatarModal from '../components/AvatarModal'
-import WarningBanner from '../components/WarningBanner'
+import SelectCard from '../components/SelectCard'
 
 const styles = theme => ({
   root: {
@@ -31,11 +31,6 @@ const styles = theme => ({
     flexDirection: 'row',
     justifyContent: 'flex-start'
   },
-  paper: {
-    padding: theme.spacing(2),
-    color: theme.palette.text.secondary,
-    display: 'flex'
-  },
   grow: {
     flexGrow: 1
   }
@@ -43,10 +38,6 @@ const styles = theme => ({
 
 function CourseList (props) {
   const { classes, user } = props
-
-  if (!user.relatedCourses && !user.isSuperuser) {
-    return (<WarningBanner>You are not enrolled in any courses with My Learning Analytics enabled.</WarningBanner>)
-  }
 
   const [avatarEl, setAvatarEl] = useState(null)
   const avatarOpen = Boolean(avatarEl)
@@ -86,23 +77,24 @@ function CourseList (props) {
       </AppBar>
       <div className={classes.content}>
         {
-          user.isSuperuser
-            ? <Grid container spacing={2}>
-              <Grid item xs={12}>
-                <Paper className={classes.paper}>
-                  <Typography variant='h5' gutterBottom>Select a course of your choice</Typography>
-                </Paper>
+          !user.relatedCourses.length
+            ? (
+              <AlertBanner>
+                You are not enrolled in any courses with My Learning Analytics enabled. 
+                Visit the <MuiLink href={user.helpURL} color='link'>Help site</MuiLink> for more information about this tool.
+              </AlertBanner>
+            )
+            : (
+              <Grid container spacing={2}>
+                <Grid item xs={12} className={classes.container}>
+                  {user.relatedCourses.map((course, key) =>
+                    <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
+                      <SelectCard cardData={{ title: course.course_name }} />
+                    </Link>
+                  )}
+                </Grid>
               </Grid>
-            </Grid>
-            : <Grid container spacing={2}>
-              <Grid item xs={12} className={classes.container}>
-                {user.relatedCourses.map((course, key) =>
-                  <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`} key={key}>
-                    <SelectCard cardData={{ title: course.course_name }} />
-                  </Link>
-                )}
-              </Grid>
-            </Grid>
+            )
         }
       </div>
     </>

--- a/assets/src/defaultPalette.js
+++ b/assets/src/defaultPalette.js
@@ -13,6 +13,10 @@ const defaultPalette = {
      This value was arrived at through research and design work; use caution when modifying. */
   negative: {
     main: '#B5B5B5'
+  },
+  /* The 'link' color is used to identify text and icons in views that link to external resources. */
+  link: {
+    main: '#0000EE'
   }
 }
 


### PR DESCRIPTION
This PR changes the logic in the `CourseList` container so that all users not enrolled in a course with MyLA enabled have the same user experience (regardless of whether they are a superuser or not). Providing an alternative to the somewhat confusing results detailed in issue #785, these changes make it so all unenrolled users see an `AlertBanner` informing them of the application state and linking to the help page. To incorporate the help page link with the rest of the application, I also updated the `defaultPalette` to include a standard link blue and updated hardcoded uses of this color elsewhere in the application. Note that the link color in the `AlertBanner` seems to change to purple when clicked (I saw this behavior in Firefox, Chrome, and Safari). The PR aims to resolve issue #785.

Task List:
- [x] Add `link` color to `defaultPalette.js`
- [x] Update `createResourceAccessChart.js` `d3` component to use theme for link color
- [x] In `CourseList`, remove initial conditional checking if the user is a regular user with no enrolled courses (seems like such users should still be able to see the `AppBar`).
- [x] Change logic so all users with no `relatedCourses` see the same message
- [x] Import the Material UI `Link` component, aliased as `MuiLink`
- [x] Create an `AlertBanner` informing users they have no MyLA enrollments and link to help site
- [x] Fix `standard` style issues with ternary operator indentation by using parentheses
- [x] Reorder imports in `CourseList`