### PR TITLE
Added '%' to bar labels for Better Readability

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -142,7 +142,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .text(d => (
         ((mainYScale(d.resource_name) + mainYScale.bandwidth() / 2) < miniHeight) &&
         ((mainYScale(d.resource_name) + mainYScale.bandwidth() / 2) > 0))
-        ? d.total_count
+        ? d.total_count + '%'
         : ''
       )
 


### PR DESCRIPTION
This PR addresses issue #887 and adds '%' symbols to the bars for better readability.