### PR TITLE
Smoother Keyboard Traversing of Buttons on Index Page

### DIFF
--- a/assets/src/containers/IndexPage.js
+++ b/assets/src/containers/IndexPage.js
@@ -43,7 +43,7 @@ function IndexPage (props) {
           spacing={8}
         >
           {routes(courseId, views).map((props, key) =>
-            <Link style={{ textDecoration: 'none' }} to={props.path} key={key}>
+            <Link tabIndex={-1} style={{ textDecoration: 'none' }} to={props.path} key={key}>
               <SelectCard cardData={props} />
             </Link>
           )}


### PR DESCRIPTION
Tabbing through the Index Page will not make users press tab twice to traverse to next button. This PR addresses issue #907.

![Feb-28-2020 16-46-57](https://user-images.githubusercontent.com/33735083/75589907-108d5900-5a4a-11ea-9302-3c48b9bf68ee.gif)
