### PR TITLE
Make Resources Accessed resize gracefully, re-work spacing (#694)

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -71,7 +71,7 @@ function appendLegend (svg) {
 function createResourceAccessChart ({ data, width, height, domElement }) {
   const resourceData = data.sort((a, b) => b.total_percent - a.total_percent)
 
-  const sideMarginSize = width * 0.05
+  const sideMarginSize = width * 0.075
   const margin = { top: 0, right: sideMarginSize, bottom: 0, left: sideMarginSize }
 
   const [availWidth, availHeight] = adjustViewport(width, height, margin)
@@ -115,8 +115,9 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
   // Build the chart
   const svg = d3.select(domElement).append('svg')
     .attr('class', 'svgWrapper')
-    .attr('width', mainMargin.left + mainWidth + mainMargin.right + miniMargin.left + miniWidth + miniMargin.right)
-    .attr('height', mainMargin.top + mainHeight + mainMargin.bottom)
+    .attr('width', availWidth)
+    .attr('height', availHeight)
+    .attr('transform', `translate(${margin.left}, ${margin.top})`)
     .on('wheel.zoom', scroll)
     .on('mousedown.zoom', null) // Override the center selection
     .on('touchstart.zoom', null)
@@ -153,11 +154,10 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .enter()
       .append('text')
       .attr('class', 'label')
-      .attr('x', d => mainXScale(d.total_percent) + 3 + margin.left + mainMargin.left)
-      .attr('y', d => mainYScale(d.resource_name) + mainYScale.bandwidth() / 2 + margin.top + mainMargin.top)
+      .attr('x', d => mainXScale(d.total_percent) + 3 + mainMargin.left)
+      .attr('y', d => mainYScale(d.resource_name) + mainYScale.bandwidth() / 2 + mainMargin.top)
       .attr('dx', -10)
       .attr('dy', '.35em')
-      .style('font-size', 10)
       .style('fill', d => d.self_access_count > 0 ? 'white' : 'black')
       .attr('text-anchor', 'end')
       .text(d => (
@@ -259,7 +259,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
   // Main chart group
   const mainGroup = svg.append('g')
     .attr('class', 'mainGroupWrapper')
-    .attr('transform', `translate(${margin.left + mainMargin.left}, ${margin.top + mainMargin.top})`)
+    .attr('transform', `translate(${mainMargin.left}, ${mainMargin.top})`)
     .append('g')
     .attr('clip-path', 'url(#clip)')
     .style('clip-path', 'url(#clip)')
@@ -267,8 +267,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   // Mini chart group
 
-  const miniTopLeftX = margin.left + mainMargin.left + mainWidth + mainMargin.right + miniMargin.left
-  const miniTopLeftY = margin.top + miniMargin.top
+  const miniTopLeftX = mainMargin.left + mainWidth + mainMargin.right + miniMargin.left
+  const miniTopLeftY = miniMargin.top
 
   const miniGroup = svg.append('g')
     .attr('class', 'miniGroup')

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -16,6 +16,9 @@ import { siteTheme } from '../../globals'
 const accessedResourceColor = siteTheme.palette.secondary.main
 const notAccessedResourceColor = siteTheme.palette.negative.main
 const linkColor = siteTheme.palette.link.main
+
+// foreignObjSide specifies the length of one side of the square foreign object element that contains the
+// resource icon and padding to its right; this value is also used to calculate the resourceLabelWidth.
 const foreignObjSide = 24
 
 const toolTip = d3tip().attr('class', 'd3-tip')
@@ -93,10 +96,21 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
   const [availWidth, availHeight] = adjustViewport(width, height, margin)
 
   /*
-  The decimal multipliers for mainMargin.left, mainWidth, mainMargin.right, miniMargin.left,
-  miniWidth, and miniMargin.right should add up to 1.0. In other words, the sum of those values
-  should be equal to the availWidth.
+  The decimal multipliers for values along the horizontal axis should add up to 1.0. In other words,
+  the sum of the horizontal values should be equal to the availWidth. Specifically,
+
+  availWidth = mainMargin.left + mainWidth + mainMargin.right + miniMargin.left + miniWidth + miniMargin.right
+
+  Because the main and mini charts share horizontal space, the decimal multipliers for
+  values along the vertical axis for each chart should add up to 1.0. In other words, the sum of the
+  vertical values for one chart should be equal to the availHeight. To keep the charts aligned,
+  the corresponding segment values from each chart should be equal. Specifically,
+
+  availHeight = mainMargin.top + mainHeight + mainMargin.bottom
+  availHeight = miniMargin.top + miniHeight + miniMargin.top
+  mainMargin.top = miniMargin.top, mainHeight = miniHeight, mainMargin.bottom = miniMargin.bottom
   */
+
   const mainWidth = availWidth * 0.55
   const mainHeight = availHeight * 0.7
   const mainMargin = {
@@ -105,7 +119,6 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     bottom: availHeight * 0.15,
     left: availWidth * 0.225
   }
-  const resourceLabelWidth = mainMargin.left * 0.889 - foreignObjSide
 
   const miniWidth = availWidth * 0.20
   const miniHeight = mainHeight
@@ -115,6 +128,10 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     bottom: availHeight * 0.15,
     left: availWidth * 0.025
   }
+
+  // The space available for a resource label should be mainMargin.left minus the margin between
+  // the main and mini charts, minus the horizontal length of the foreign object element.
+  const resourceLabelWidth = mainMargin.left - miniMargin.left - foreignObjSide
 
   const defaultNumberOfResources = 7
   const selectionWindowHeight = resourceData.length < defaultNumberOfResources

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -16,7 +16,7 @@ import { siteTheme } from '../../globals'
 const accessedResourceColor = siteTheme.palette.secondary.main
 const notAccessedResourceColor = siteTheme.palette.negative.main
 const linkColor = siteTheme.palette.link.main
-const foriegnObjSide = 24
+const foreignObjSide = 24
 
 const toolTip = d3tip().attr('class', 'd3-tip')
   .direction('n').offset([-5, 5])
@@ -105,7 +105,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     bottom: availHeight * 0.15,
     left: availWidth * 0.225
   }
-  const resourcelabelWidth = mainMargin.left * 0.889 - foriegnObjSide
+  const resourcelabelWidth = mainMargin.left * 0.889 - foreignObjSide
 
   const miniWidth = availWidth * 0.20
   const miniHeight = mainHeight
@@ -250,9 +250,9 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
         : 0.5
       )
 
-    // Update the resource labels on Y axis
+    // Update the resource label names on Y axis
     d3.selectAll('.axis--y .tick text')
-      .attr('x', (mainMargin.left - foriegnObjSide) * -1)
+      .attr('x', (mainMargin.left - foreignObjSide) * -1)
       .attr('fill', linkColor)
       .style('font-size', textScale(selected.length))
       .call(truncate, resourcelabelWidth)
@@ -399,7 +399,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   brushmove()
 
-  // Truncate resource label name on Y axis
+  // Truncate resource label names on Y axis
   d3.selectAll('.axis--y .tick text')
     .call(truncate, resourcelabelWidth)
 
@@ -419,8 +419,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     d3.select(this).insert('foreignObject')
       .attr('x', mainMargin.left * -1)
       .attr('y', -6)
-      .attr('width', foriegnObjSide)
-      .attr('height', foriegnObjSide)
+      .attr('width', foreignObjSide)
+      .attr('height', foreignObjSide)
       .attr('color', linkColor)
       .append('xhtml:i')
       .attr('class', icon)

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -79,23 +79,23 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
   // Pixel fallback is to ensure the legend and X axis label do not disappear
   const verticalChartMargin = (availHeight * 0.15) > 50 ? (availHeight * 0.15) : 50
 
+  const mainWidth = availWidth * 0.55
+  const mainHeight = availHeight * 0.7
   const mainMargin = {
     top: verticalChartMargin,
     right: 0,
     bottom: verticalChartMargin,
     left: availWidth * 0.225
   }
-  const mainWidth = availWidth * 0.55
-  const mainHeight = availHeight * 0.7
 
+  const miniWidth = availWidth * 0.20
+  const miniHeight = mainHeight
   const miniMargin = {
     top: verticalChartMargin,
     right: 0,
     bottom: verticalChartMargin,
     left: availWidth * 0.025
   }
-  const miniWidth = availWidth * 0.20
-  const miniHeight = mainHeight
 
   const defaultNumberOfResources = 7
   const selectionWindowHeight = resourceData.length < defaultNumberOfResources
@@ -254,7 +254,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     gBrush.call(brush.move, [center - size / 2, center + size / 2])
   }
 
-  const truncate = (text) => text.length > 30 ? `${text.substring(0, 30)}...` : text
+  const truncate = (text) => text.length > 32 ? `${text.substring(0, 32)}...` : text
 
   // Main chart group
   const mainGroup = svg.append('g')

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -76,24 +76,21 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   const [availWidth, availHeight] = adjustViewport(width, height, margin)
 
-  // Pixel fallback is to ensure the legend and X axis label do not disappear
-  const verticalChartMargin = (availHeight * 0.15) > 50 ? (availHeight * 0.15) : 50
-
   const mainWidth = availWidth * 0.55
   const mainHeight = availHeight * 0.7
   const mainMargin = {
-    top: verticalChartMargin,
+    top: availHeight * 0.15,
     right: 0,
-    bottom: verticalChartMargin,
+    bottom: availHeight * 0.15,
     left: availWidth * 0.225
   }
 
   const miniWidth = availWidth * 0.20
   const miniHeight = mainHeight
   const miniMargin = {
-    top: verticalChartMargin,
+    top: availHeight * 0.15,
     right: 0,
-    bottom: verticalChartMargin,
+    bottom: availHeight * 0.15,
     left: availWidth * 0.025
   }
 

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -16,7 +16,7 @@ import { siteTheme } from '../../globals'
 const accessedResourceColor = siteTheme.palette.secondary.main
 const notAccessedResourceColor = siteTheme.palette.negative.main
 const linkColor = siteTheme.palette.link.main
-const iconSize = 24
+const foriegnObjSide = 24
 
 const toolTip = d3tip().attr('class', 'd3-tip')
   .direction('n').offset([-5, 5])
@@ -92,6 +92,11 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   const [availWidth, availHeight] = adjustViewport(width, height, margin)
 
+  /*
+  The decimal multipliers for mainMargin.left, mainWidth, mainMargin.right, miniMargin.left,
+  miniWidth, and miniMargin.right should add up to 1.0. In other words, the sum of those values
+  should be equal to the availWidth.
+  */
   const mainWidth = availWidth * 0.55
   const mainHeight = availHeight * 0.7
   const mainMargin = {
@@ -100,7 +105,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     bottom: availHeight * 0.15,
     left: availWidth * 0.225
   }
-  const labelWidth = mainMargin.left * 0.889 - iconSize
+  const resourcelabelWidth = mainMargin.left * 0.889 - foriegnObjSide
 
   const miniWidth = availWidth * 0.20
   const miniHeight = mainHeight
@@ -160,8 +165,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .on('mouseover', toolTip.show)
       .on('mouseout', toolTip.hide)
 
-    // Append text to bars
-    // Seems like this could be rewritten to use the bars?
+    // Append percentage value text to bars
     svg.selectAll('.label').remove()
     svg.selectAll('.label')
       .data(resourceData)
@@ -248,10 +252,10 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
     // Update the resource labels on Y axis
     d3.selectAll('.axis--y .tick text')
-      .attr('x', (mainMargin.left - iconSize) * -1)
+      .attr('x', (mainMargin.left - foriegnObjSide) * -1)
       .attr('fill', linkColor)
       .style('font-size', textScale(selected.length))
-      .call(truncate, labelWidth)
+      .call(truncate, resourcelabelWidth)
 
     update()
   }
@@ -279,7 +283,6 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('class', 'mainGroup')
 
   // Mini chart group
-
   const miniTopLeftX = mainMargin.left + mainWidth + mainMargin.right + miniMargin.left
   const miniTopLeftY = miniMargin.top
 
@@ -398,7 +401,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   // Truncate resource label name on Y axis
   d3.selectAll('.axis--y .tick text')
-    .call(truncate, labelWidth)
+    .call(truncate, resourcelabelWidth)
 
   // Add links and icons to Y axis
   d3.selectAll('.axis--y .tick').each(function (d) {
@@ -416,8 +419,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     d3.select(this).insert('foreignObject')
       .attr('x', mainMargin.left * -1)
       .attr('y', -6)
-      .attr('width', iconSize)
-      .attr('height', iconSize)
+      .attr('width', foriegnObjSide)
+      .attr('height', foriegnObjSide)
       .attr('color', linkColor)
       .append('xhtml:i')
       .attr('class', icon)

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -105,7 +105,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     bottom: availHeight * 0.15,
     left: availWidth * 0.225
   }
-  const resourcelabelWidth = mainMargin.left * 0.889 - foreignObjSide
+  const resourceLabelWidth = mainMargin.left * 0.889 - foreignObjSide
 
   const miniWidth = availWidth * 0.20
   const miniHeight = mainHeight
@@ -255,7 +255,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('x', (mainMargin.left - foreignObjSide) * -1)
       .attr('fill', linkColor)
       .style('font-size', textScale(selected.length))
-      .call(truncate, resourcelabelWidth)
+      .call(truncate, resourceLabelWidth)
 
     update()
   }
@@ -401,7 +401,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   // Truncate resource label names on Y axis
   d3.selectAll('.axis--y .tick text')
-    .call(truncate, resourcelabelWidth)
+    .call(truncate, resourceLabelWidth)
 
   // Add links and icons to Y axis
   d3.selectAll('.axis--y .tick').each(function (d) {

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -16,7 +16,6 @@ import { siteTheme } from '../../globals'
 const accessedResourceColor = siteTheme.palette.secondary.main
 const notAccessedResourceColor = siteTheme.palette.negative.main
 const linkColor = siteTheme.palette.link.main
-const mainMargin = { top: 50, right: 10, bottom: 50, left: 200 }
 
 const toolTip = d3tip().attr('class', 'd3-tip')
   .direction('n').offset([-5, 5])
@@ -31,7 +30,6 @@ const toolTip = d3tip().attr('class', 'd3-tip')
   })
 
 function appendLegend (svg) {
-  const w = 800 - mainMargin.left - mainMargin.right
   const legendBoxLength = 10
   const legendBoxTextInterval = 15
   const legendInterval = 20
@@ -44,7 +42,7 @@ function appendLegend (svg) {
 
   const legend = svg.select('.mainGroupWrapper').append('g')
     .attr('class', 'legend')
-    .attr('transform', 'translate(-550, 0)')
+    .attr('transform', 'translate(0,0)')
 
   legend.selectAll('text')
     .data(legendLabels)
@@ -53,7 +51,7 @@ function appendLegend (svg) {
     .attr('font-family', 'sans-serif')
     .attr('font-size', '14px')
     .attr('y', (_, i) => legendY + i * legendInterval + legendBoxLength)
-    .attr('x', w + legendBoxTextInterval)
+    .attr('x', legendBoxTextInterval)
     .text(d => d[0])
 
   const legendRect = legend.selectAll('rect')
@@ -66,36 +64,59 @@ function appendLegend (svg) {
 
   legendRect
     .attr('y', (_, i) => legendY + i * legendInterval)
-    .attr('x', w)
+    .attr('x', 0)
     .style('fill', d => d[1])
 }
 
 function createResourceAccessChart ({ data, width, height, domElement }) {
   const resourceData = data.sort((a, b) => b.total_percent - a.total_percent)
 
-  const [mainWidth, miniHeight] = adjustViewport(width, height, mainMargin)
+  const sideMarginSize = width * 0.05
+  const margin = { top: 0, right: sideMarginSize, bottom: 0, left: sideMarginSize }
+
+  const [availWidth, availHeight] = adjustViewport(width, height, margin)
+
+  // Pixel fallback is to ensure the legend and X axis label do not disappear
+  const verticalChartMargin = (availHeight * 0.15) > 50 ? (availHeight * 0.15) : 50
+
+  const mainMargin = {
+    top: verticalChartMargin,
+    right: 0,
+    bottom: verticalChartMargin,
+    left: availWidth * 0.225
+  }
+  const mainWidth = availWidth * 0.55
+  const mainHeight = availHeight * 0.7
+
+  const miniMargin = {
+    top: verticalChartMargin,
+    right: 0,
+    bottom: verticalChartMargin,
+    left: availWidth * 0.025
+  }
+  const miniWidth = availWidth * 0.20
+  const miniHeight = mainHeight
 
   const defaultNumberOfResources = 7
   const selectionWindowHeight = resourceData.length < defaultNumberOfResources
-    ? miniHeight
-    : miniHeight / resourceData.length * defaultNumberOfResources
+    ? mainHeight
+    : mainHeight / resourceData.length * defaultNumberOfResources
 
   const defaultSelection = [0, selectionWindowHeight]
 
-  const miniMargin = { top: 50, right: 10, bottom: 50, left: 10 }
-  const miniWidth = 100 - miniMargin.left - miniMargin.right
+  const mainXScale = d3.scaleLinear().range([0, mainWidth])
+  let mainYScale = d3.scaleBand().range([0, mainHeight])
 
-  const mainXScale = d3.scaleLinear().range([150, mainWidth])
   const miniXScale = d3.scaleLinear().range([0, miniWidth])
-  let mainYScale = d3.scaleBand().range([0, miniHeight])
   const miniYScale = d3.scaleBand().range([0, miniHeight])
+
   const textScale = d3.scaleLinear().range([12, 6]).domain([15, 50]).clamp(true)
 
   // Build the chart
   const svg = d3.select(domElement).append('svg')
     .attr('class', 'svgWrapper')
-    .attr('width', mainWidth + mainMargin.left + mainMargin.right + miniWidth + miniMargin.left + miniMargin.right)
-    .attr('height', miniHeight + mainMargin.top + mainMargin.bottom)
+    .attr('width', mainMargin.left + mainWidth + mainMargin.right + miniMargin.left + miniWidth + miniMargin.right)
+    .attr('height', mainMargin.top + mainHeight + mainMargin.bottom)
     .on('wheel.zoom', scroll)
     .on('mousedown.zoom', null) // Override the center selection
     .on('touchstart.zoom', null)
@@ -107,16 +128,14 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .data(resourceData, d => d.resource_name)
 
     // Initialize
-    bar.attr('x', 150)
-      .attr('y', d => mainYScale(d.resource_name))
-      .attr('width', d => mainXScale(d.total_percent) - 150)
+    bar.attr('y', d => mainYScale(d.resource_name))
+      .attr('width', d => mainXScale(d.total_percent))
       .attr('height', mainYScale.bandwidth())
 
     bar.enter()
       .append('rect')
-      .attr('x', 150)
       .attr('y', d => mainYScale(d.resource_name))
-      .attr('width', d => mainXScale(d.total_percent) - 150)
+      .attr('width', d => mainXScale(d.total_percent))
       .attr('height', mainYScale.bandwidth())
       .attr('class', 'bar')
       .attr('fill', d => d.self_access_count > 0
@@ -127,21 +146,22 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .on('mouseout', toolTip.hide)
 
     // Append text to bars
+    // Seems like this could be rewritten to use the bars?
     svg.selectAll('.label').remove()
     svg.selectAll('.label')
       .data(resourceData)
       .enter()
       .append('text')
       .attr('class', 'label')
-      .attr('x', d => mainXScale(d.total_percent) + 3 + mainMargin.left)
-      .attr('y', d => mainYScale(d.resource_name) + mainYScale.bandwidth() / 2 + mainMargin.top)
+      .attr('x', d => mainXScale(d.total_percent) + 3 + margin.left + mainMargin.left)
+      .attr('y', d => mainYScale(d.resource_name) + mainYScale.bandwidth() / 2 + margin.top + mainMargin.top)
       .attr('dx', -10)
       .attr('dy', '.35em')
       .style('font-size', 10)
       .style('fill', d => d.self_access_count > 0 ? 'white' : 'black')
       .attr('text-anchor', 'end')
       .text(d => (
-        ((mainYScale(d.resource_name) + mainYScale.bandwidth() / 2) < miniHeight) &&
+        ((mainYScale(d.resource_name) + mainYScale.bandwidth() / 2) < mainHeight) &&
         ((mainYScale(d.resource_name) + mainYScale.bandwidth() / 2) > 0))
         ? d.total_percent + '%'
         : ''
@@ -214,7 +234,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
     // Update the resource labels
     d3.selectAll('.axis--y text')
-      .attr('x', -160)
+      .attr('x', (mainMargin.left - 24) * -1)
       .attr('fill', linkColor)
       .style('font-size', textScale(selected.length))
 
@@ -234,29 +254,33 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     gBrush.call(brush.move, [center - size / 2, center + size / 2])
   }
 
-  const truncate = (text) => text.length > 23 ? `${text.substring(0, 23)}...` : text
+  const truncate = (text) => text.length > 30 ? `${text.substring(0, 30)}...` : text
 
   // Main chart group
   const mainGroup = svg.append('g')
     .attr('class', 'mainGroupWrapper')
-    .attr('transform', `translate(${mainMargin.left}, ${mainMargin.top})`)
+    .attr('transform', `translate(${margin.left + mainMargin.left}, ${margin.top + mainMargin.top})`)
     .append('g')
     .attr('clip-path', 'url(#clip)')
     .style('clip-path', 'url(#clip)')
     .attr('class', 'mainGroup')
 
   // Mini chart group
+
+  const miniTopLeftX = margin.left + mainMargin.left + mainWidth + mainMargin.right + miniMargin.left
+  const miniTopLeftY = margin.top + miniMargin.top
+
   const miniGroup = svg.append('g')
     .attr('class', 'miniGroup')
-    .attr('transform', `translate(${(mainMargin.left + mainWidth + mainMargin.right + miniMargin.left)}, ${miniMargin.top})`)
+    .attr('transform', `translate(${miniTopLeftX}, ${miniTopLeftY})`)
 
   const brushGroup = svg.append('g')
     .attr('class', 'brushGroup')
-    .attr('transform', `translate(${(mainMargin.left + mainWidth + mainMargin.right + miniMargin.left)}, ${miniMargin.top})`)
+    .attr('transform', `translate(${(miniTopLeftX)}, ${miniTopLeftY})`)
 
   // Scales
-  const mainYZoom = d3.scaleLinear().range([0, miniHeight])
-    .domain([0, miniHeight])
+  const mainYZoom = d3.scaleLinear().range([0, mainHeight])
+    .domain([0, mainHeight])
 
   // Axis
   const mainXAxis = d3.axisBottom(mainXScale)
@@ -299,7 +323,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .append('rect')
     .attr('x', -mainMargin.left)
     .attr('width', mainWidth + mainMargin.left)
-    .attr('height', miniHeight)
+    .attr('height', mainHeight)
 
   // Inject data
   // Domain
@@ -313,13 +337,14 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .paddingOuter(0)
 
   // Append axis to main chart
-  const xLabel = d3.select('.mainGroupWrapper')
+  const xAxis = d3.select('.mainGroupWrapper')
     .append('g')
     .attr('class', 'axis axis--x')
-    .attr('transform', 'translate(' + 0 + ',' + (miniHeight + 5) + ')')
+    .attr('transform', `translate(0,${mainHeight})`)
     .call(mainXAxis.tickFormat(d => d + '%'))
 
-  xLabel.append('text')
+  // Append label to X axis
+  xAxis.append('text')
     .attr('fill', 'black')
     .attr('text-anchor', 'middle')
     .attr('transform', `translate(${mainWidth / 2}, 40)`)
@@ -328,7 +353,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   mainGroup.append('g')
     .attr('class', 'axis axis--y')
-    .attr('transform', 'translate(150,0)')
+    .attr('transform', 'translate(0,0)')
     .call(mainYAxis)
 
   // Draw mini bars
@@ -371,10 +396,10 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
     const icon = d.split('|')[2]
     d3.select(this).insert('foreignObject')
-      .attr('x', -180)
+      .attr('x', mainMargin.left * -1)
       .attr('y', -6)
-      .attr('width', 32)
-      .attr('height', 32)
+      .attr('width', 24)
+      .attr('height', 24)
       .attr('color', linkColor)
       .append('xhtml:i')
       .attr('class', icon)

--- a/assets/src/containers/ResourcesAccessed.js
+++ b/assets/src/containers/ResourcesAccessed.js
@@ -217,6 +217,7 @@ function ResourcesAccessed (props) {
         <ResourceAccessChart
           data={resourceData}
           aspectRatio={0.3}
+          minHeight={400}
         />
       )
     }

--- a/assets/src/containers/ResourcesAccessed.js
+++ b/assets/src/containers/ResourcesAccessed.js
@@ -217,7 +217,7 @@ function ResourcesAccessed (props) {
         <ResourceAccessChart
           data={resourceData}
           aspectRatio={0.3}
-          minHeight={400}
+          minHeight={350}
         />
       )
     }

--- a/assets/src/containers/ResourcesAccessed.js
+++ b/assets/src/containers/ResourcesAccessed.js
@@ -214,12 +214,10 @@ function ResourcesAccessed (props) {
       return (<AlertBanner>Resource data for your selections is not available.</AlertBanner>)
     } else {
       return (
-        <Grid item xs={12} lg={10}>
-          <ResourceAccessChart
-            data={resourceData}
-            aspectRatio={0.3}
-          />
-        </Grid>
+        <ResourceAccessChart
+          data={resourceData}
+          aspectRatio={0.3}
+        />
       )
     }
   }

--- a/assets/src/hooks/useResponsiveness.js
+++ b/assets/src/hooks/useResponsiveness.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { createResize } from '../util/chart'
 
 const useResponsiveness = props => {
-  const { domElement, aspectRatio = 0.75 } = props
+  const { domElement, aspectRatio = 0.75, minHeight = null } = props
   const [width, setWidth] = useState(null)
 
   const setContainer = () => {
@@ -18,7 +18,11 @@ const useResponsiveness = props => {
     return optimizedResize.remove
   })
 
-  return [width, width * aspectRatio]
+  const height = (minHeight) && (width * aspectRatio < minHeight)
+    ? minHeight
+    : (width * aspectRatio)
+
+  return [width, height]
 }
 
 export default useResponsiveness


### PR DESCRIPTION
This PR makes significant changes to the Resources Accessed view to make spacing more consistent and the charts and text respond appropriately to changing window sizes. It accomplishes this by introducing percent-based calculations of component sizes and coordinates, removing the use of a `Grid` component wrapper, and truncating text based on pixel length. The task list and commentary below provide more details on the changes. The PR aims to resolve issue #694.

- [x] Remove `Grid` wrapper for chart from the `ResourcesAccessed` container.
- [x] Determine width, height, and margin sizes for the `main` and `mini` charts based on decimals; update coordinates, translations, and references accordingly.
- [x] Modify `useResponsiveness` hook to allow for an optional `minHeight` to help prevent text from getting jumbled in smaller windows.
- [x] Rewrite `truncate` function so it uses `getCompetedTextLength`; thanks to @pushyamig for putting me on the right track.

Note that this PR does not fix all current issues with the view, but hopefully it makes strides toward improving the user experience in general and making it easier for developers to change things quickly with less potential for bugs.

Regarding the new `truncate` method, I have seen some discussion on forums and in blogs suggesting that `getComputedTextLength` can be time-intensive. Please let me know if you think the view has become more laggy to the point where it is disruptive; it seems OK to me at the moment, but more testing may be needed. I chose this route because it seemed the simplest to integrate with the current implementation.