### PR TITLE
Changed Selected Button Behavior in Sidebar

### DIFF
--- a/assets/src/containers/SideDrawer.js
+++ b/assets/src/containers/SideDrawer.js
@@ -54,7 +54,7 @@ function SideDrawer (props) {
             <ListItemIcon>
               {selectedIndex === key
                 ? <props.icon color='secondary' />
-                : <props.icon style={{color: '#E1E1E1'}}/>
+                : <props.icon color='negative'/>
               }
             </ListItemIcon>
             <ListItemText primary={props.title} className={classes.text} />

--- a/assets/src/containers/SideDrawer.js
+++ b/assets/src/containers/SideDrawer.js
@@ -49,10 +49,14 @@ function SideDrawer (props) {
             to={props.path}
             key={key}
             className={classes.sideDrawerLinks}
-            selected={selectedIndex === key}
             onClick={() => setSelectedIndex(key)}
           >
-            <ListItemIcon><props.icon /></ListItemIcon>
+            <ListItemIcon>
+              {selectedIndex === key
+                ? <props.icon color='secondary' />
+                : <props.icon style={{color: '#E1E1E1'}}/>
+              }
+            </ListItemIcon>
             <ListItemText primary={props.title} className={classes.text} />
           </ListItem>
         ))}


### PR DESCRIPTION
This PR aims to remove the ambiguity between selected and current view button in the sidebar. Fixes issue #896.

### Current:
<img width="281" alt="Screen Shot 2020-03-06 at 2 38 02 PM" src="https://user-images.githubusercontent.com/33735083/76116523-248c0a00-5fb8-11ea-9728-53e8ad6cda26.png">


### This PR:
<img width="288" alt="Screen Shot 2020-03-06 at 2 28 00 PM" src="https://user-images.githubusercontent.com/33735083/76116386-e7277c80-5fb7-11ea-9335-2bbaab09a747.png">
