### PR TITLE
Fixes #873 - Display course in cron where earliest found

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -59,7 +59,7 @@ class CourseAdmin(admin.ModelAdmin):
     _courseviewoption.short_description = "Course View Option(s)"
 
     def course_link(self, obj):
-        return format_html('<a href="{}">Link</a>', obj.get_absolute_url())
+        return format_html('<a href="{}">Link</a>', obj.absolute_url)
 
     # When saving the course, update the id based on canvas id
     def save_model(self, request, obj, form, change):

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -9,15 +9,13 @@ logger = logging.getLogger(__name__)
 
 
 def find_earliest_start_datetime_of_courses():
-    course_start_datetimes = []
-    for course in Course.objects.all():
-        course_start_datetimes.append(course.get_course_date_range().start)
-    logger.debug(course_start_datetimes)
+    sorted_courses = sorted(Course.objects.all(), key=lambda course: course.course_date_range.start)
 
-    earliest_start = None
-    if len(course_start_datetimes) > 0:
-        earliest_start = sorted(course_start_datetimes)[0]
-        logger.info(f"Earliest start datetime for all courses: {earliest_start.isoformat()}")
+    earliest_course = None
+    if len(sorted_courses) > 0:
+        earliest_course = sorted_courses[0]
+        earliest_start = earliest_course.course_date_range.start
+        logger.info(f"Earliest start datetime for all courses: {earliest_start.isoformat()} found in course {earliest_course.canvas_id}")
     else:
         logger.info(f"No course listed. Return None as the earliest_start_datetime_of_course. ")
     return earliest_start

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def find_earliest_start_datetime_of_courses():
     sorted_courses = sorted(Course.objects.all(), key=lambda course: course.course_date_range.start)
 
-    earliest_course = None
+    earliest_start = None
     if len(sorted_courses) > 0:
         earliest_course = sorted_courses[0]
         earliest_start = earliest_course.course_date_range.start

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -489,7 +489,7 @@ class DashboardCronJob(CronJobBase):
 
 
     def do(self):
-        logger.info("** dashboard cron tab")
+        logger.info("** MyLA cron tab")
 
         status = ""
 

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -177,7 +177,8 @@ class Course(models.Model):
     def __str__(self):
         return self.name
 
-    def get_course_date_range(self):
+    @property
+    def course_date_range(self):
         if self.date_start is not None:
             start = self.date_start
         elif self.term is not None and self.term.date_start is not None:
@@ -195,7 +196,8 @@ class Course(models.Model):
         DateRange = namedtuple("DateRange", ["start", "end"])
         return DateRange(start, end)
 
-    def get_absolute_url(self):
+    @property
+    def absolute_url(self):
         return reverse('courses', kwargs={'course_id': self.canvas_id})
 
     class Meta:

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
     # This is the courses catch-all. Most user-initiated requests will match the regular expression; then the React
     # front-end will manage any additional routing.
     re_path(r'^courses/', login_required(views.get_home_template,), name="courses"),
-    # This path is used by Course.get_absolute_url() to generate course links for the Admin interface.
+    # This path is used by Course.absolute_url to generate course links for the Admin interface.
     path('courses/<int:course_id>/', login_required(views.get_home_template,), name="courses"),
 
     # These URLs are data patterns

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -96,7 +96,7 @@ def get_course_info(request, course_id=0):
 
     resp = model_to_dict(course)
 
-    course_start, course_end = course.get_course_date_range()
+    course_start, course_end = course.course_date_range
 
     current_week_number = math.ceil((today - course_start).days/7)
     total_weeks = math.ceil((course_end - course_start).days/7)
@@ -622,7 +622,7 @@ def is_weight_considered(course_id):
 
 def get_course_date_start(course_id):
     logger.info(get_course_date_start.__name__)
-    course_date_start = Course.objects.get(id=course_id).get_course_date_range().start
+    course_date_start = Course.objects.get(id=course_id).course_date_range.start
     return course_date_start
 
 


### PR DESCRIPTION
* This changes the two methods in the model for Course to a property so they can be more directly accessed.

* It also sorts the objects by this value so the object id can be re-used later.

* It also has a rename of dashboard in the cron as we don't need to see that in the logs anymore