### PR TITLE
Smoother CourseList Keyboard Navigation

### DIFF
--- a/assets/src/containers/CourseList.js
+++ b/assets/src/containers/CourseList.js
@@ -89,7 +89,7 @@ function CourseList (props) {
                 {
                   user.relatedCourses.map((course, key) => (
                     <Grid item xs={12} sm={6} lg={4} key={key}>
-                      <Link style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`}>
+                      <Link tabIndex={-1} style={{ textDecoration: 'none' }} to={`/courses/${course.course_id}`}>
                         <SelectCard cardData={{ title: course.course_name }} />
                       </Link>
                     </Grid>


### PR DESCRIPTION
This PR address #921 by giving the `<Link>` element in `CourseList.js` a tabIndex value of -1.