### PR TITLE
I918 reordering migration files

### DIFF
--- a/dashboard/migrations/0014_add_auto_field_to_resources.py
+++ b/dashboard/migrations/0014_add_auto_field_to_resources.py
@@ -14,7 +14,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dashboard', '0014_auto_20200116_1408'),
+        ('dashboard', '0013_course_show_grade_type'),
     ]
 
     operations = [

--- a/dashboard/migrations/0015_auto_20200116_1408.py
+++ b/dashboard/migrations/0015_auto_20200116_1408.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dashboard', '0013_course_show_grade_type'),
+        ('dashboard', '0014_add_auto_field_to_resources'),
     ]
 
     operations = [


### PR DESCRIPTION
This issue is ordering the migration files so that assignment redesign migration  file comes last in order to support a release for 2020.1.x with fix #918 which doesn't include the assignment redesign course