### PR TITLE
reverse scrolling direction for resource view

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -212,7 +212,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     const range = miniYScale.range()
     const y0 = d3.min(range)
     const y1 = d3.max(range) + miniYScale.bandwidth()
-    const dy = d3.event.deltaY
+    const dy = d3.event.deltaY * -1
     const topSection = selection[0] - dy < y0
       ? y0
       : selection[1] - dy > y1

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -205,14 +205,18 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     bar.exit().remove()
   }
 
-  function scroll () {
+  function scroll (e) {
     // Mouse scroll on the chart
     const selection = d3.brushSelection(gBrush.node())
     const size = selection[1] - selection[0]
     const range = miniYScale.range()
     const y0 = d3.min(range)
     const y1 = d3.max(range) + miniYScale.bandwidth()
-    const dy = d3.event.deltaY * -1
+    const direction = event.webkitDirectionInvertedFromDevice
+    const dy = -d3.event.deltaY
+    if (direction < 0) {
+      dy *= -1
+    }
     const topSection = selection[0] - dy < y0
       ? y0
       : selection[1] - dy > y1

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -205,7 +205,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     bar.exit().remove()
   }
 
-  function scroll (e) {
+  function scroll () {
     // Mouse scroll on the chart
     const selection = d3.brushSelection(gBrush.node())
     const size = selection[1] - selection[0]


### PR DESCRIPTION
This PR fixes #913 by changing multiplying the `dy` value by -1 in the `scroll` function when creating the chart in `createResourceAccessChart.js`.