### PR TITLE
Avoid warnings by using siteTheme.palette.negative.main, palette.link.main (#930)

### DIFF
--- a/assets/src/containers/CourseList.js
+++ b/assets/src/containers/CourseList.js
@@ -9,6 +9,7 @@ import MuiLink from '@material-ui/core/Link'
 import Popover from '@material-ui/core/Popover'
 import Toolbar from '@material-ui/core/Toolbar'
 import Typography from '@material-ui/core/Typography'
+import { siteTheme } from '../globals'
 import AlertBanner from '../components/AlertBanner'
 import AvatarModal from '../components/AvatarModal'
 import SelectCard from '../components/SelectCard'
@@ -81,7 +82,8 @@ function CourseList (props) {
             ? (
               <AlertBanner>
                 You are not enrolled in any courses with My Learning Analytics enabled.
-                Visit the <MuiLink href={user.helpURL} color='link'>Help site</MuiLink> for more information about this tool.
+                Visit the <MuiLink href={user.helpURL} style={{ color: siteTheme.palette.link.main }}>Help site</MuiLink> for
+                more information about this tool.
               </AlertBanner>
             )
             : (

--- a/assets/src/containers/SideDrawer.js
+++ b/assets/src/containers/SideDrawer.js
@@ -6,6 +6,7 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import { Link, withRouter } from 'react-router-dom'
+import { siteTheme } from '../globals'
 import routes from '../routes/routes'
 import Spinner from '../components/Spinner'
 
@@ -52,9 +53,10 @@ function SideDrawer (props) {
             onClick={() => setSelectedIndex(key)}
           >
             <ListItemIcon>
-              {selectedIndex === key
-                ? <props.icon color='secondary' />
-                : <props.icon color='negative'/>
+              {
+                selectedIndex === key
+                  ? <props.icon color='secondary' />
+                  : <props.icon style={{ color: siteTheme.palette.negative.main }} />
               }
             </ListItemIcon>
             <ListItemText primary={props.title} className={classes.text} />

--- a/assets/src/defaultPalette.js
+++ b/assets/src/defaultPalette.js
@@ -9,12 +9,16 @@ const defaultPalette = {
   secondary: {
     main: '#2C6496'
   },
-  /* The 'negative' color is used currently to indicate a negative, un-completed, un-viewed, or un-selected state.
-     This value was arrived at through research and design work; use caution when modifying. */
+  /* The 'negative' color is used currently to indicate a negative, un-completed, un-viewed, or un-selected
+     state. This value was arrived at through research and design work; use caution when modifying. For now,
+     this should be used directly through theme.palette.negative.main instead of the color prop
+     (i.e. color='negative'), which isn't fully supported. */
   negative: {
     main: '#B5B5B5'
   },
-  /* The 'link' color is used to identify text and icons in views that link to external resources. */
+  /* The 'link' color is used to identify text and icons in views that link to external resources. For now,
+     this should be used directly through theme.palette.link.main instead of the color prop
+     (i.e. color='link'), which isn't fully supported. */
   link: {
     main: '#0000EE'
   }


### PR DESCRIPTION
This PR updates usages of the custom colors `negative` and `link` in the theme's palette so that they directly access the hex values through `siteTheme.palette.{color}.main` instead of through `color={color}`, which results in console warnings. The comments in `defaultPalette.js` were updated to reflect this. The PR aims to resolve issue #930.

It seems like we'll have to wait for Material UI 5 for full custom color support.