### PR TITLE
Bring back "View on Site" on "Change Course" page (#936)

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -200,6 +200,9 @@ class Course(models.Model):
     def absolute_url(self):
         return reverse('courses', kwargs={'course_id': self.canvas_id})
 
+    def get_absolute_url(self):
+        return self.absolute_url
+
     class Meta:
         db_table = "course"
         verbose_name = "Course"


### PR DESCRIPTION
This PR makes a minor modification to `dashboard/models.py` to re-enable a "View on Site" button available from the "Change Course" page in the Django admin. This seems to have been lost in an earlier PR when `get_absolute_url` (which has special meaning to Django) was changed to a `@property` implementation with `absolute_url`. The fix here merely re-creates the `get_absolute_url` method and leverages the aforementioned property. The PR aims to resolve issue #936 

"Change Course" admin page with change:

![Screen Shot 2020-05-26 at 4 48 17 PM](https://user-images.githubusercontent.com/35741256/82949717-14aa1380-9f72-11ea-8824-c02098281c43.png)

The course referenced above is fabricated.