### PR TITLE
Fixed rounding bug

### DIFF
--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -14,6 +14,7 @@ import PopupMessage from './PopupMessage'
 import ConditionalWrapper from './ConditionalWrapper'
 import StyledTextField from './StyledTextField'
 import { calculateWeekOffset } from '../util/date'
+import { roundToXDecimals } from '../util/math'
 
 const styles = theme => ({
   root: {
@@ -188,7 +189,7 @@ function AssignmentTable (props) {
                       {a.name}
                     </TableCell>
                     <TableCell className={classes.narrowCell}>
-                      {`${a.percentOfFinalGrade}%`}
+                      {`${roundToXDecimals(a.percentOfFinalGrade, 1)}%`}
                     </TableCell>
                     <TableCell style={{ width: '20%' }}>
                       {
@@ -199,7 +200,7 @@ function AssignmentTable (props) {
                               error={(a.goalGrade / a.pointsPossible) > 1}
                               disabled={!courseGoalGradeSet}
                               id='standard-number'
-                              value={a.goalGrade}
+                              value={roundToXDecimals(a.goalGrade, 1)}
                               label={
                                 !courseGoalGradeSet ? 'Set a goal'
                                   : (a.goalGrade / a.pointsPossible) > 1

--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -14,7 +14,7 @@ import PopupMessage from './PopupMessage'
 import ConditionalWrapper from './ConditionalWrapper'
 import StyledTextField from './StyledTextField'
 import { calculateWeekOffset } from '../util/date'
-import { roundToXDecimals } from '../util/math'
+import { roundToXDecimals, getDecimalPlaceOfFloat } from '../util/math'
 
 const styles = theme => ({
   root: {
@@ -104,6 +104,10 @@ function AssignmentTable (props) {
       ? assignments[key - 1].dueDateMonthDay === dueDateMonthDay
       : false
   }
+
+  // Use decimal place of pointsPossible if it's a decimal; otherwise, round to nearest tenth
+  const placeToRoundTo = pointsPossible => (String(pointsPossible).includes('.'))
+    ? getDecimalPlaceOfFloat(pointsPossible) : 1
 
   // this effect scrolls to current week of assignments if it exists
   useEffect(() => {
@@ -200,7 +204,7 @@ function AssignmentTable (props) {
                               error={(a.goalGrade / a.pointsPossible) > 1}
                               disabled={!courseGoalGradeSet}
                               id='standard-number'
-                              value={roundToXDecimals(a.goalGrade, 1)}
+                              value={roundToXDecimals(a.goalGrade, placeToRoundTo(a.pointsPossible))}
                               label={
                                 !courseGoalGradeSet ? 'Set a goal'
                                   : (a.goalGrade / a.pointsPossible) > 1

--- a/assets/src/util/assignment.js
+++ b/assets/src/util/assignment.js
@@ -1,5 +1,5 @@
 import { calculateWeekOffset, dateToMonthDay } from './date'
-import { sum, roundToXDecimals, getDecimalPlaceOfFloat } from './math'
+import { sum, roundToXDecimals } from './math'
 
 const clearGoals = assignments => assignments
   .map(a => {
@@ -21,15 +21,11 @@ const setAssigmentGoalInputState = (key, assignments, inputFocus) => {
 }
 
 const setAssignmentGoalGrade = (key, assignments, goalGrade) => {
-  // Use decimal place of pointsPossible if it's a decimal; otherwise, round to nearest tenth
-  const placeToRoundTo = (String(assignments[key].pointsPossible).includes('.'))
-    ? getDecimalPlaceOfFloat(assignments[key].pointsPossible) : 1
-
   return [
     ...assignments.slice(0, key),
     {
       ...assignments[key],
-      goalGrade: goalGrade === '' ? '' : roundToXDecimals(Number(goalGrade), placeToRoundTo),
+      goalGrade: goalGrade === '' ? '' : roundToXDecimals(Number(goalGrade), 3),
       goalGradeSetByUser: goalGrade
     },
     ...assignments.slice(key + 1)
@@ -95,7 +91,7 @@ const calculateAssignmentGoalsFromCourseGoal = (
 
   return assignments.map(a => {
     if (notGradedOrGoalGradeSetByUser(a) && a.inputBlur) {
-      a.goalGrade = roundToXDecimals(requiredGrade * a.pointsPossible, 1) || ''
+      a.goalGrade = roundToXDecimals(requiredGrade * a.pointsPossible, 3) || ''
     }
     return a
   })


### PR DESCRIPTION
Resolves #881.

I was able to reproduce the bug - it's caused by rounding as you suspected @ssciolla. 

I fixed by rounding to one decimal when the numbers are displayed in `AssignmentTable`. I also had to round in `assignment` because every time the state changes, GraphQL needs to store the floats and I was getting an error from GraphQL that the floats were too large - I decided to round to 3 decimal places for the internal state, which resolves the rounding error. 