### PR TITLE
Enable term management, improve cron methods (#963)

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -51,6 +51,9 @@ class TermAdmin(admin.ModelAdmin):
     list_display = ('canvas_id', 'name', 'date_start', 'date_end')
     readonly_fields = ('canvas_id', 'name')
 
+    def has_add_permission(self, request, obj=None):
+        return False
+
 
 class CourseAdmin(admin.ModelAdmin):
     inlines = [CourseViewOptionInline, ]

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -51,7 +51,7 @@ class TermAdmin(admin.ModelAdmin):
     list_display = ('canvas_id', 'name', 'date_start', 'date_end')
     readonly_fields = ('canvas_id', 'name')
 
-    def has_add_permission(self, request, obj=None):
+    def has_add_permission(self, request):
         return False
 
 

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,14 +1,14 @@
-from django.contrib import admin
 from django import forms
 from django.conf import settings
+from django.contrib import admin
+from django.forms.models import ModelForm
+from django.template.defaultfilters import linebreaksbr
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.template.defaultfilters import linebreaksbr
 
 from dashboard.common.db_util import canvas_id_to_incremented_id
-from .models import CourseViewOption, Course
+from dashboard.models import AcademicTerms, Course, CourseViewOption
 
-from django.forms.models import ModelForm
 
 # Always save the OneToOne Fields
 # https://stackoverflow.com/a/3734700/3708872
@@ -46,6 +46,12 @@ class CourseForm(forms.ModelForm):
         return self.cleaned_data
 
 
+class TermAdmin(admin.ModelAdmin):
+    exclude = ('id',)
+    list_display = ('canvas_id', 'name', 'date_start', 'date_end')
+    readonly_fields = ('canvas_id', 'name')
+
+
 class CourseAdmin(admin.ModelAdmin):
     inlines = [CourseViewOptionInline, ]
     form = CourseForm
@@ -66,5 +72,5 @@ class CourseAdmin(admin.ModelAdmin):
         obj.id = canvas_id_to_incremented_id(obj.canvas_id)
         return super(CourseAdmin, self).save_model(request, obj, form, change)
 
-
+admin.site.register(AcademicTerms, TermAdmin)
 admin.site.register(Course, CourseAdmin)

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -445,11 +445,11 @@ class DashboardCronJob(CronJobBase):
 
         existing_terms_ids: List[int] = [term.id for term in list(AcademicTerms.objects.all())]
         new_term_ids: List[int] = [int(id) for id in warehouse_term_df['id'].to_list() if id not in existing_terms_ids]
-        new_term_df: pd.DataFrame = warehouse_term_df.loc[warehouse_term_df['id'].isin(new_term_ids)]
 
-        if len(new_term_ids) == 0:
+        if not new_term_ids:
             logger.info('No new terms were found to add to the academic_terms table.')
         else:
+            new_term_df: pd.DataFrame = warehouse_term_df.loc[warehouse_term_df['id'].isin(new_term_ids)]
             try:
                 new_term_df.to_sql(con=engine, name='academic_terms', if_exists='append', index=False)
                 term_message: str = f'Added {len(new_term_df)} new records to academic_terms table: {new_term_ids}'
@@ -497,7 +497,7 @@ class DashboardCronJob(CronJobBase):
             )
             updated_fields += soft_update_datetime_field(course, 'date_end', warehouse_date_end)
 
-            if len(updated_fields) > 0:
+            if updated_fields:
                 course.save()
                 status += f'Course {course.id}: updated {", ".join(updated_fields)}\n'
         return status

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -1,6 +1,6 @@
 import datetime, logging
 from collections import namedtuple
-from typing import Any, Dict, List, Union
+from typing import Dict, List, Union
 
 import pandas as pd
 import pytz

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -445,7 +445,6 @@ class DashboardCronJob(CronJobBase):
 
         existing_terms_ids: List[int] = [term.id for term in list(AcademicTerms.objects.all())]
         new_term_ids: List[int] = [int(id) for id in warehouse_term_df['id'].to_list() if int(id) not in existing_terms_ids]
-        logger.debug(new_term_ids)
         new_term_df: pd.DataFrame = warehouse_term_df.loc[warehouse_term_df['id'].isin(new_term_ids)]
 
         if len(new_term_ids) == 0:
@@ -453,7 +452,7 @@ class DashboardCronJob(CronJobBase):
         else:
             try:
                 new_term_df.to_sql(con=engine, name='academic_terms', if_exists='append', index=False)
-                term_message: str = f'Added {len(new_term_df)} new records to academic_terms table.'
+                term_message: str = f'Added {len(new_term_df)} new records to academic_terms table: {new_term_ids}'
                 logger.info(term_message)
                 status += term_message + '\n'
             except Exception as e:

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -84,7 +84,7 @@ def soft_update_datetime_field(
     warehouse_field_value: Union[datetime.datetime, None],
 ) -> List[str]:
     """
-    Use Django ORM to compare warehouse and existing data and, if null, update DateTime field of model instance.
+    Uses Django ORM to update DateTime field of model instance if the field value is null and the warehouse data is non-null.
     """
     model_name: str = model_inst.__class__.__name__
     current_field_value: Union[datetime.datetime, None] = getattr(model_inst, field_name)

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -489,11 +489,11 @@ class DashboardCronJob(CronJobBase):
                 updated_fields.append('term')
 
             warehouse_date_start: Union[datetime.datetime, None] = (
-                warehouse_course_dict['start_at'].to_pydatetime() if warehouse_course_dict['start_at'] is not None else None
+                warehouse_course_dict['start_at'].to_pydatetime() if pd.notna(warehouse_course_dict['start_at']) else None
             )
             updated_fields += soft_update_datetime_field(course, 'date_start', warehouse_date_start)
             warehouse_date_end: Union[datetime.datetime, None] = (
-                warehouse_course_dict['conclude_at'].to_pydatetime() if warehouse_course_dict['conclude_at'] is not None else None
+                warehouse_course_dict['conclude_at'].to_pydatetime() if pd.notna(warehouse_course_dict['conclude_at']) else None
             )
             updated_fields += soft_update_datetime_field(course, 'date_end', warehouse_date_end)
 

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -453,8 +453,9 @@ class DashboardCronJob(CronJobBase):
         else:
             try:
                 new_term_df.to_sql(con=engine, name='academic_terms', if_exists='append', index=False)
-                logger.info(f'Added {len(new_term_df)} new records to academic_terms table.')
-                status += f'Added {len(new_term_df)} new records to academic_terms table.\n'
+                term_message: str = f'Added {len(new_term_df)} new records to academic_terms table.'
+                logger.info(term_message)
+                status += term_message + '\n'
             except Exception as e:
                 logger.error(f'Error running to_sql on term table: {e}')
                 raise

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -85,7 +85,7 @@ def soft_update_datetime_field(
     warehouse_field_name: str
 ) -> List[str]:
     """
-    Use Django ORM to compare warehouse and existing course data and, if necessary, update DateTime field of model instance.
+    Use Django ORM to compare warehouse and existing course data and, if null, update DateTime field of model instance.
     """
     course_field_value = getattr(course_obj, course_field_name)
     # Skipping update if the field already has a value, provided by a previous cron run or administrator
@@ -435,7 +435,7 @@ class DashboardCronJob(CronJobBase):
         return status
 
 
-    def update_term(self) -> None:
+    def update_term(self) -> str:
         """
         Searches for new terms in data from warehouse, leaves existing terms as they are.
         """

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -444,7 +444,7 @@ class DashboardCronJob(CronJobBase):
         warehouse_term_df: pd.DataFrame = pd.read_sql(term_sql, conns['DATA_WAREHOUSE'])
 
         existing_terms_ids: List[int] = [term.id for term in list(AcademicTerms.objects.all())]
-        new_term_ids: List[int] = [int(id) for id in warehouse_term_df['id'].to_list() if int(id) not in existing_terms_ids]
+        new_term_ids: List[int] = [int(id) for id in warehouse_term_df['id'].to_list() if id not in existing_terms_ids]
         new_term_df: pd.DataFrame = warehouse_term_df.loc[warehouse_term_df['id'].isin(new_term_ids)]
 
         if len(new_term_ids) == 0:

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -435,7 +435,7 @@ class DashboardCronJob(CronJobBase):
 
     def update_term(self) -> str:
         """
-        Searches for new terms in data from warehouse, leaves existing terms as they are.
+        Searches warehouse data for new terms and adds them while leaving existing terms as they are.
         """
         status: str = ''
         logger.info('update_term()')

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -90,7 +90,7 @@ def soft_update_datetime_field(
     current_field_value: Union[datetime.datetime, None] = getattr(model_inst, field_name)
     # Skipping update if the field already has a value, provided by a previous cron run or administrator
     if current_field_value is not None:
-        logger.info(f'Skipped update of {field_name} for {model_name} instance ({model_inst.id}); existing value was found.')
+        logger.info(f'Skipped update of {field_name} for {model_name} instance ({model_inst.id}); existing value was found')
     else:
         if warehouse_field_value:
             warehouse_field_value = warehouse_field_value.replace(tzinfo=pytz.UTC)
@@ -433,7 +433,6 @@ class DashboardCronJob(CronJobBase):
 
         return status
 
-
     def update_term(self) -> str:
         """
         Searches for new terms in data from warehouse, leaves existing terms as they are.
@@ -460,7 +459,6 @@ class DashboardCronJob(CronJobBase):
                 logger.error(f'Error running to_sql on term table: {e}')
                 raise
         return status
-
 
     def update_course(self, warehouse_courses_data: pd.DataFrame) -> str:
         """


### PR DESCRIPTION
This PR modifies the existing `update_term` and `update_course` cron methods so that only new terms are added to the database, and existing terms are not updated. It also adds an Admin view for `AcademicTerms`, only allowing users to edit the start and end dates. Additionally, the changes include some unrelated improvements to `update_course` and a function it uses, `soft_update_datetime_field`, to make the code clearer and more generally useful. The PR aims to resolve issue #963.