### PR TITLE
API to support course config settings (#985)

### DIFF
--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -11,6 +11,7 @@ import Spinner from '../components/Spinner'
 import { isObjectEmpty } from '../util/object'
 import { useCourseInfo } from '../service/api'
 import WarningBanner from '../components/WarningBanner'
+import AlertBanner from '../components/AlertBanner'
 
 function Course (props) {
   const { courseId, user } = props
@@ -23,7 +24,7 @@ function Course (props) {
     }
     setSideDrawerState(open)
   }
-
+  
   if (error.message === 'Not Found') return (<WarningBanner>Course {courseId} does not exist.</WarningBanner>)
   else if (error.message === 'Forbidden') return (<WarningBanner>You do not have access to course {courseId}.</WarningBanner>)
   else if (error) return (<WarningBanner />)
@@ -47,54 +48,65 @@ function Course (props) {
               courseId={courseId}
               courseInfo={courseInfo}
             />
-            <Route
-              path='/courses/:courseId/'
-              exact
-              render={props =>
-                <IndexPage
-                  {...props}
-                  courseInfo={courseInfo}
-                  courseId={courseId}
-                />}
-            />
-            <Route
-              path='/courses/:courseId/grades'
-              render={props =>
-                <GradeDistribution
-                  {...props}
-                  disabled={!courseInfo.course_view_options.gd}
-                  courseId={courseId}
-                  user={user}
-                />}
-            />
-            <Route
-              path='/courses/:courseId/assignmentsv1'
-              render={props =>
-                <AssignmentPlanning
-                  {...props}
-                  disabled={!courseInfo.course_view_options.apv1}
-                  courseId={courseId}
-                />}
-            />
-            <Route
-              path='/courses/:courseId/assignments'
-              render={props =>
-                <AssignmentPlanningV2
-                  {...props}
-                  disabled={!courseInfo.course_view_options.ap}
-                  courseId={courseId}
-                />}
-            />
-            <Route
-              path='/courses/:courseId/resources'
-              render={props =>
-                <ResourcesAccessed
-                  {...props}
-                  disabled={!courseInfo.course_view_options.ra}
-                  courseInfo={courseInfo}
-                  courseId={courseId}
-                />}
-            />
+            {courseInfo.course_user_exist === 0
+              ? (
+                <>
+                  <AlertBanner>
+                    No data is available for {courseInfo.name} yet. Please wait for the next system data load.
+                  </AlertBanner>
+                </>
+              ) : (
+                <>
+                  <Route
+                    path='/courses/:courseId/'
+                    exact
+                    render={props =>
+                      <IndexPage
+                        {...props}
+                        courseInfo={courseInfo}
+                        courseId={courseId}
+                      />}
+                  />
+                  <Route
+                    path='/courses/:courseId/grades'
+                    render={props =>
+                      <GradeDistribution
+                        {...props}
+                        disabled={!courseInfo.course_view_options.gd}
+                        courseId={courseId}
+                        user={user}
+                      />}
+                  />
+                  <Route
+                    path='/courses/:courseId/assignmentsv1'
+                    render={props =>
+                      <AssignmentPlanning
+                        {...props}
+                        disabled={!courseInfo.course_view_options.apv1}
+                        courseId={courseId}
+                      />}
+                  />
+                  <Route
+                    path='/courses/:courseId/assignments'
+                    render={props =>
+                      <AssignmentPlanningV2
+                        {...props}
+                        disabled={!courseInfo.course_view_options.ap}
+                        courseId={courseId}
+                      />}
+                  />
+                  <Route
+                    path='/courses/:courseId/resources'
+                    render={props =>
+                      <ResourcesAccessed
+                        {...props}
+                        disabled={!courseInfo.course_view_options.ra}
+                        courseInfo={courseInfo}
+                        courseId={courseId}
+                      />}
+                  />
+                </>
+              )}
           </>
         ) : <Spinner />}
     </>

--- a/dashboard/rules.py
+++ b/dashboard/rules.py
@@ -66,6 +66,7 @@ is_admin_or_instructor_in_course_id = is_admin | is_instructor_in_course_id
 
 # api
 rules.add_perm('dashboard.get_course_info', is_admin_or_enrolled_in_course)
+rules.add_perm('dashboard.update_course_info', is_admin_or_instructor_in_course)
 rules.add_perm('dashboard.resource_access_within_week', is_admin_or_enrolled_in_course)
 rules.add_perm('dashboard.grade_distribution', is_admin_or_enrolled_in_course)
 rules.add_perm('dashboard.update_user_default_selection_for_views', is_admin_or_enrolled_in_course)

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -65,6 +65,8 @@ urlpatterns = [
     # PUT/POST access patterns
     path('api/v1/courses/<int:course_id>/set_user_default_selection/',
         login_required(views.update_user_default_selection_for_views), name='update_user_default_selection_for_views'),
+    path('api/v1/courses/<int:course_id>/update_info/',
+        login_required(views.update_course_info), name='update_course_info'),
 
     path('su/', include('django_su.urls')),
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -19,7 +19,7 @@ from dashboard.common import utils
 from django.core.exceptions import ObjectDoesNotExist
 from collections import namedtuple
 
-from dashboard.models import Course, CourseViewOption, Resource, UserDefaultSelection
+from dashboard.models import Course, CourseViewOption, Resource, UserDefaultSelection, User
 from dashboard.settings import RESOURCE_VALUES, RESOURCE_VALUES_MAP, RESOURCE_ACCESS_CONFIG
 from dashboard.settings import COURSES_ENABLED
 
@@ -127,6 +127,9 @@ def get_course_info(request, course_id=0):
     resp['total_weeks'] = total_weeks
     resp['course_view_options'] = CourseViewOption.objects.get(course=course).json(include_id=False)
     resp['resource_types'] = course_resource_list
+
+    course_users_list = User.objects.filter(course_id=course_id)
+    resp['course_user_exist'] = 1 if len(course_users_list) > 0 else 0
 
     return HttpResponse(json.dumps(resp, default=str))
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -467,7 +467,6 @@ def update_user_default_selection_for_views(request, course_id=0):
     :return: HttpResponse containing `{"default": "success"}` or `{"default": "fail"}`
     """
     logger.info(update_user_default_selection_for_views.__name__)
-    logger.info(request)
     course_id = canvas_id_to_incremented_id(course_id)
     current_user = request.user.get_username()
     default_selection = json.loads(request.body.decode("utf-8"))

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -218,7 +218,8 @@ def update_course_info(request, course_id=0):
             f'updating course visualization options failed due to {e} for user {current_user} in course {course_id}')
         success = False
 
-    return JsonResponse({'default': 'success' if success else 'fail'})
+    return JsonResponse({'default': 'success' if success else 'fail'},
+                        status=200 if success else 500)
 
 
 # show percentage of users who read the resource within prior n weeks

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,11 +1,11 @@
 import json
 import logging
+import math
 from collections import namedtuple
 from datetime import timedelta
 from json import JSONDecodeError
 
 import jsonschema
-import math
 import numpy as np
 import pandas as pd
 from django.conf import settings
@@ -13,7 +13,7 @@ from django.contrib import auth
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection as conn
 from django.forms.models import model_to_dict
-from django.http import HttpResponse, HttpResponseForbidden, HttpResponseBadRequest, JsonResponse
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import redirect, render
 from django.utils import timezone
 from pinax.eventlog.models import log as eventlog
@@ -23,8 +23,8 @@ from dashboard.common import utils
 from dashboard.common.db_util import canvas_id_to_incremented_id
 from dashboard.event_logs_types.event_logs_types import EventLogTypes
 from dashboard.models import Course, CourseViewOption, Resource, UserDefaultSelection, User
-from dashboard.settings import COURSES_ENABLED
-from dashboard.settings import RESOURCE_VALUES, RESOURCE_VALUES_MAP, RESOURCE_ACCESS_CONFIG
+from dashboard.settings import COURSES_ENABLED, RESOURCE_VALUES, RESOURCE_VALUES_MAP, \
+    RESOURCE_ACCESS_CONFIG
 
 logger = logging.getLogger(__name__)
 # strings for construct resource download url
@@ -144,17 +144,17 @@ def update_course_info(request, course_id=0):
 
     :param request: HTTP `PUT` req.; body should contain the JSON body…
     :param course_id: Integer Canvas course ID number, typically six digits or less.
-    :return: HttpResponse containing `{"default": "success"}` or `{"default": "fail"}`
+    :return: JsonResponse containing `{"default": "success"}` or `{"default": "fail"}`
     """
     logger.info(update_course_info.__name__)
 
     if (request.method != 'PUT'):
-        return HttpResponseBadRequest(JsonResponse({'error': 'Invalid request method.'}))
+        return JsonResponse({'error': 'Invalid request method.'}, status=400)
 
     course_id = canvas_id_to_incremented_id(course_id)
     current_user = request.user.get_username()
 
-    bad_json_response = HttpResponseBadRequest(JsonResponse({'error': 'Request JSON malformed.'}))
+    bad_json_response = JsonResponse({'error': 'Request JSON malformed.'}, status=400)
 
     try:
         request_data: dict = json.loads(request.body.decode('utf-8'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,5 @@ django-ptvsd-debug==1.0.3
 django-lti-auth==1.0.0
 django-webpack-loader==0.6.0
 django-csp==3.5
+
+jsonschema==3.2.0


### PR DESCRIPTION
Resolves #985.

Accepts JSON payloads in the request body of the format:

```json
{
  "ap": { "enabled": true },
  "apv1": { "enabled": false },
  "gd": { "enabled": true, "show_grade_counts": true },
  "ra": { "enabled": true }
}
```

Where each of the root-level keys are optional, but at least one must be given.  The `enabled` key is required for any object given.  The `show_grade_counts` key for the `gd` object is optional.  If it is not given, that option won't be updated.

The "jsonschema" module is used for input validation.

Of the four items listed in the requirements for #985, I've not yet tested whether non-instructors are disallowed from using this new API entry.

I'm unsure under which conditions this API entry will be used, so I'm not sure whether the Django model updating code I used requires additional error handling.

I wouldn't be surprised if this needs some tweaks.  However, as I'm taking several days off from work next week, I wanted to try to get something working committed so that @chrisrrowland could potentially use it with the UI code he's developing.