### PR TITLE
#987 optimizing and compressing webpack assets

### DIFF
--- a/dashboard/templates/frontend/index.html
+++ b/dashboard/templates/frontend/index.html
@@ -12,4 +12,5 @@
     <div id="root"></div>
     <!-- Webpack rendered JS -->
     {% render_bundle 'main' 'js' %}
+    {% render_bundle 'vendors' 'js' %}
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "webpack-cli": "~3.2.3",
     "webpack-dev-server": "~3.2.1",
     "webpack-manifest-plugin": "2.0.4",
-    "workbox-webpack-plugin": "4.1.0"
+    "workbox-webpack-plugin": "4.1.0",
+    "compression-webpack-plugin": "~4.0.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const BundleTracker = require('webpack-bundle-tracker')
+const CompressionPlugin = require('compression-webpack-plugin')
 
 module.exports = {
   entry: path.join(__dirname, 'assets/src/index'),
@@ -27,10 +28,28 @@ module.exports = {
       }
     ]
   },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          name: 'vendors',
+          test: /[\\/]node_modules[\\/]/,
+          chunks: 'all'
+        }
+      }
+    }
+  },
   plugins: [
     new BundleTracker({
       path: __dirname,
       filename: 'webpack-stats.json'
+    }),
+    new CompressionPlugin({
+      filename: '[path].gz[query]',
+      algorithm: 'gzip',
+      test: /\.js(\?.*)?$/i,
+      threshold: 10240,
+      minRatio: 0.8
     })
   ]
 }


### PR DESCRIPTION
I was able to split the single JS file to source code + vendor assets and Was able to compress it as. I see issues with compression is implemented. `django-webpack-loader` depends on `webpack-bundle-tracker`

1. `index.html` simply says 
```
{% render_bundle 'main' 'js' %}
    {% render_bundle 'vendors' 'js' %}
```
2. webpack-stats.json content is 
```
{
  "status": "done",
  "chunks": {
    "main": [
      {
        "name": "main-e5185de39171058cfd22.js",
        "path": "/usr/src/app/assets/dist/main-e5185de39171058cfd22.js"
      }
    ],
    "vendors": [
      {
        "name": "vendors-e5185de39171058cfd22.js",
        "path": "/usr/src/app/assets/dist/vendors-e5185de39171058cfd22.js"
      }
    ]
  }
}
```



1. When webpack is set on prod mode I can see that browser is loading the gzip content. 
![Screen Shot 2020-07-28 at 2 48 17 PM](https://user-images.githubusercontent.com/8579775/88708376-90931a00-d0e1-11ea-97b0-4c6ae650f5ce.png)

```
webpack_watcher    |       main-e5185de39171058cfd22.js   384 KiB     main  [emitted]  main
webpack_watcher    |    main-e5185de39171058cfd22.js.gz  47.1 KiB           [emitted]
webpack_watcher    |    vendors-e5185de39171058cfd22.js  16.1 MiB  vendors  [emitted]  vendors
webpack_watcher    | vendors-e5185de39171058cfd22.js.gz  1.49 MiB           [emitted]
```
![Screen Shot 2020-07-28 at 12 04 39 PM](https://user-images.githubusercontent.com/8579775/88707822-c97ebf00-d0e0-11ea-8c8b-2cdad6b19427.png)

2. Webpack in watch mode a change on react code updates both `main` and `vendor` mode but compression of the vendor packages doesn't work. I am really not sure why this is the case

   1. With regards to `webpack-bundle-tracker` a new update is available but it has some [breaking](https://github.com/owais/webpack-bundle-tracker/issues/52#issuecomment-599245547) `webpack-stats.json ` structure that python [loader](https://github.com/owais/webpack-bundle-tracker/issues/52#issuecomment-602064536) fails to load the json. Either I have to write my own Python loader class to support this as started [here](https://github.com/owais/django-webpack-loader/#loader_class) 

With version `"webpack-bundle-tracker": "^0.4.3",` and `django-webpack-loader==0.7.0` things kind of works but upgrading to webpack-bundle-tracker": "1.0.0-alpha.1 " breaks stuff. Need to spend sometime as their documentation is very basic and i have been looking at github issues to understand what exactly going on
