### PR TITLE
Update graphene-django

### DIFF
--- a/dashboard/graphql/loaders.py
+++ b/dashboard/graphql/loaders.py
@@ -21,10 +21,6 @@ class AssignmentsByCourseIdLoader(DataLoader):
         return Promise.resolve([results.get(key, []) for key in keys])
 
 class AssignmentByCourseIdAndIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|id:{key.get('id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -54,10 +50,6 @@ class AssignmentsByAssignmentGroupIdLoader(DataLoader):
         return Promise.resolve([results.get(key, []) for key in keys])
 
 class AssignmentByAssignmentGroupIdAndIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"assignment_group_id:{key.get('assignment_group_id')}|id:{key.get('id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -87,10 +79,6 @@ class SubmissionsByAssignmentIdLoader(DataLoader):
         return Promise.resolve([results.get(key, []) for key in keys])
 
 class SubmissionByAssignmentIdAndUserIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"assignment_id:{key.get('assignment_id')}|user_id:{key.get('user_id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -121,10 +109,6 @@ class AssignmentGroupsByCourseIdLoader(DataLoader):
 
 
 class AssignmentGroupByCourseIdAndIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|id:{key.get('id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -155,10 +139,6 @@ class AssignmentWeightConsiderationByCourseIdLoader(DataLoader):
         return Promise.resolve([results.get(key, None) for key in keys])
 
 class UserDefaultSelectionsByCourseIdAndUserLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(list)
 
@@ -179,10 +159,6 @@ class UserDefaultSelectionsByCourseIdAndUserLoader(DataLoader):
         ])
 
 class UserDefaultSelectionByCourseIdAndUserAndViewTypeLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}|default_view_type:{key.get('default_view_type')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 

--- a/dashboard/graphql/view.py
+++ b/dashboard/graphql/view.py
@@ -20,18 +20,42 @@ logger = logging.getLogger(__name__)
 class DashboardGraphQLView(GraphQLView):
     def get_context(self, request):
         loaders = {
-            'assignment_weight_consideration_by_course_id_loader': AssignmentWeightConsiderationByCourseIdLoader(),
-            'assignment_by_course_id_and_id_loader': AssignmentByCourseIdAndIdLoader(),
-            'assignments_by_course_id_loader': AssignmentsByCourseIdLoader(),
-            'assignment_by_assignment_group_id_and_id_loader': AssignmentByAssignmentGroupIdAndIdLoader(),
-            'assignments_by_assignment_group_id_loader': AssignmentsByAssignmentGroupIdLoader(),
-            'submissions_by_assignment_id_loader': SubmissionsByAssignmentIdLoader(),
-            'submission_by_assignment_id_and_user_id_loader': SubmissionByAssignmentIdAndUserIdLoader(),
-            'assignment_groups_by_course_id_loader': AssignmentGroupsByCourseIdLoader(),
-            'assignment_group_by_course_id_and_id_loader': AssignmentGroupByCourseIdAndIdLoader(),
-            'user_default_selections_by_course_id_and_user_loader': UserDefaultSelectionsByCourseIdAndUserLoader(),
-            'user_default_selection_by_course_id_and_user_and_view_type_loader': UserDefaultSelectionByCourseIdAndUserAndViewTypeLoader(),
-            'academic_term_by_id_loader': AcademicTermByIdLoader(),
+            'assignment_weight_consideration_by_course_id_loader': AssignmentWeightConsiderationByCourseIdLoader(
+                 get_cache_key=(lambda key: key)
+            ),
+            'assignment_by_course_id_and_id_loader': AssignmentByCourseIdAndIdLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|id:{key.get('id')}")
+            ),
+            'assignments_by_course_id_loader': AssignmentsByCourseIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'assignment_by_assignment_group_id_and_id_loader': AssignmentByAssignmentGroupIdAndIdLoader(
+                get_cache_key=(lambda key: f"assignment_group_id:{key.get('assignment_group_id')}|id:{key.get('id')}")
+            ),
+            'assignments_by_assignment_group_id_loader': AssignmentsByAssignmentGroupIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'submissions_by_assignment_id_loader': SubmissionsByAssignmentIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'submission_by_assignment_id_and_user_id_loader': SubmissionByAssignmentIdAndUserIdLoader(
+                get_cache_key=(lambda key: f"assignment_id:{key.get('assignment_id')}|user_id:{key.get('user_id')}")
+            ),
+            'assignment_groups_by_course_id_loader': AssignmentGroupsByCourseIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'assignment_group_by_course_id_and_id_loader': AssignmentGroupByCourseIdAndIdLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|id:{key.get('id')}")
+            ),
+            'user_default_selections_by_course_id_and_user_loader': UserDefaultSelectionsByCourseIdAndUserLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}")
+            ),
+            'user_default_selection_by_course_id_and_user_and_view_type_loader': UserDefaultSelectionByCourseIdAndUserAndViewTypeLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}|default_view_type:{key.get('default_view_type')}")
+            ),
+            'academic_term_by_id_loader': AcademicTermByIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
         }
         for method_, instance in loaders.items():
             setattr(request, method_, instance)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,11 +13,8 @@ django-settings-export>=1.2.1,<1.2.99
 django-macros>=0.4.0,<0.4.99
 django-debug-toolbar>=2.0,<2.0.99
 
-# Force this version of promise because the newest version doesn't support dict
-promise==2.2.1
-
 # graphql
-graphene-django>=2.8.0,<2.8.99
+graphene-django>=2.12.1,<2.12.99
 django-filter>=2.2.0,<2.2.99
 
 # object-level permissions


### PR DESCRIPTION
Dataloaders `get_cache_key` function moved from an easy overwritten class function to being set by an instance param on init. Moved the `get_cache_key` to the where the loaders are initialized (not 100% clean but it is the easiest way to pass the function in).

Closes #994 