### PR TITLE
I952 package update to latest 

### DIFF
--- a/dashboard/graphql/loaders.py
+++ b/dashboard/graphql/loaders.py
@@ -21,10 +21,6 @@ class AssignmentsByCourseIdLoader(DataLoader):
         return Promise.resolve([results.get(key, []) for key in keys])
 
 class AssignmentByCourseIdAndIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|id:{key.get('id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -54,10 +50,6 @@ class AssignmentsByAssignmentGroupIdLoader(DataLoader):
         return Promise.resolve([results.get(key, []) for key in keys])
 
 class AssignmentByAssignmentGroupIdAndIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"assignment_group_id:{key.get('assignment_group_id')}|id:{key.get('id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -87,10 +79,6 @@ class SubmissionsByAssignmentIdLoader(DataLoader):
         return Promise.resolve([results.get(key, []) for key in keys])
 
 class SubmissionByAssignmentIdAndUserIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"assignment_id:{key.get('assignment_id')}|user_id:{key.get('user_id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -121,10 +109,6 @@ class AssignmentGroupsByCourseIdLoader(DataLoader):
 
 
 class AssignmentGroupByCourseIdAndIdLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|id:{key.get('id')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 
@@ -155,10 +139,6 @@ class AssignmentWeightConsiderationByCourseIdLoader(DataLoader):
         return Promise.resolve([results.get(key, None) for key in keys])
 
 class UserDefaultSelectionsByCourseIdAndUserLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(list)
 
@@ -179,10 +159,6 @@ class UserDefaultSelectionsByCourseIdAndUserLoader(DataLoader):
         ])
 
 class UserDefaultSelectionByCourseIdAndUserAndViewTypeLoader(DataLoader):
-    # overwrite get_cache_key since it doesn't handle dictionaries
-    def get_cache_key(self, key):  # type: ignore
-        return f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}|default_view_type:{key.get('default_view_type')}"
-
     def batch_load_fn(self, keys):
         results = defaultdict(None)
 

--- a/dashboard/graphql/view.py
+++ b/dashboard/graphql/view.py
@@ -20,18 +20,42 @@ logger = logging.getLogger(__name__)
 class DashboardGraphQLView(GraphQLView):
     def get_context(self, request):
         loaders = {
-            'assignment_weight_consideration_by_course_id_loader': AssignmentWeightConsiderationByCourseIdLoader(),
-            'assignment_by_course_id_and_id_loader': AssignmentByCourseIdAndIdLoader(),
-            'assignments_by_course_id_loader': AssignmentsByCourseIdLoader(),
-            'assignment_by_assignment_group_id_and_id_loader': AssignmentByAssignmentGroupIdAndIdLoader(),
-            'assignments_by_assignment_group_id_loader': AssignmentsByAssignmentGroupIdLoader(),
-            'submissions_by_assignment_id_loader': SubmissionsByAssignmentIdLoader(),
-            'submission_by_assignment_id_and_user_id_loader': SubmissionByAssignmentIdAndUserIdLoader(),
-            'assignment_groups_by_course_id_loader': AssignmentGroupsByCourseIdLoader(),
-            'assignment_group_by_course_id_and_id_loader': AssignmentGroupByCourseIdAndIdLoader(),
-            'user_default_selections_by_course_id_and_user_loader': UserDefaultSelectionsByCourseIdAndUserLoader(),
-            'user_default_selection_by_course_id_and_user_and_view_type_loader': UserDefaultSelectionByCourseIdAndUserAndViewTypeLoader(),
-            'academic_term_by_id_loader': AcademicTermByIdLoader(),
+            'assignment_weight_consideration_by_course_id_loader': AssignmentWeightConsiderationByCourseIdLoader(
+                 get_cache_key=(lambda key: key)
+            ),
+            'assignment_by_course_id_and_id_loader': AssignmentByCourseIdAndIdLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|id:{key.get('id')}")
+            ),
+            'assignments_by_course_id_loader': AssignmentsByCourseIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'assignment_by_assignment_group_id_and_id_loader': AssignmentByAssignmentGroupIdAndIdLoader(
+                get_cache_key=(lambda key: f"assignment_group_id:{key.get('assignment_group_id')}|id:{key.get('id')}")
+            ),
+            'assignments_by_assignment_group_id_loader': AssignmentsByAssignmentGroupIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'submissions_by_assignment_id_loader': SubmissionsByAssignmentIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'submission_by_assignment_id_and_user_id_loader': SubmissionByAssignmentIdAndUserIdLoader(
+                get_cache_key=(lambda key: f"assignment_id:{key.get('assignment_id')}|user_id:{key.get('user_id')}")
+            ),
+            'assignment_groups_by_course_id_loader': AssignmentGroupsByCourseIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
+            'assignment_group_by_course_id_and_id_loader': AssignmentGroupByCourseIdAndIdLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|id:{key.get('id')}")
+            ),
+            'user_default_selections_by_course_id_and_user_loader': UserDefaultSelectionsByCourseIdAndUserLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}")
+            ),
+            'user_default_selection_by_course_id_and_user_and_view_type_loader': UserDefaultSelectionByCourseIdAndUserAndViewTypeLoader(
+                get_cache_key=(lambda key: f"course_id:{key.get('course_id')}|user_sis_name:{key.get('user_sis_name')}|default_view_type:{key.get('default_view_type')}")
+            ),
+            'academic_term_by_id_loader': AcademicTermByIdLoader(
+                get_cache_key=(lambda key: key)
+            ),
         }
         for method_, instance in loaders.items():
             setattr(request, method_, instance)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn>=19.9.0,<19.9.99
+gunicorn==20.0.4
 
 Django==3.0.8
 whitenoise==5.1.0
@@ -45,9 +45,7 @@ google-cloud-bigquery==1.26.0
 pinax-eventlog==2.0.3
 ptvsd==4.3.2
 django-ptvsd-debug==1.0.3
-django-lti-auth==1.0.0
 PyLTI1p3==1.7.0
 django-webpack-loader==0.6.0
-django-csp==3.5
-
 jsonschema==3.2.0
+django-csp==3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,52 +1,53 @@
-gunicorn==20.0.4
+gunicorn>=19.9.0,<19.9.99
 
-# We're waiting on Django 3 until it's further into the lifecycle.
 Django==3.0.8
 whitenoise==5.1.0
 
-django-registration>=3.0,<3.0.99
-django-cron>=0.5.1,<0.5.99
-django-npm>=1.0.0,<1.0.99
+django-registration==3.1
+# No update since 2018
+django-cron==0.5.1
+# No update since 2016
+django-npm==1.0.0
 django-watchman==1.1.1
-django-su>=0.8.0,<0.8.99
-django-settings-export>=1.2.1,<1.2.99
-django-macros>=0.4.0,<0.4.99
-django-debug-toolbar>=2.0,<2.0.99
+django-su==0.9.0
+# No update since 2016
+django-settings-export==1.2.1
+# No update since 2015
+django-macros==0.4.0
+django-debug-toolbar==2.2
 django-mysql==3.7.1
-# Force this version of promise because the newest version doesn't support dict
-promise==2.2.1
 
 # graphql
-graphene-django>=2.12.1,<2.12.99
-django-filter>=2.2.0,<2.2.99
+graphene-django==2.12.1
+django-filter==2.3.0
 
 # object-level permissions
 rules==2.2
-django-model-utils>=3.2.0,<3.2.99
+django-model-utils==4.0.0
 
 # These should be okay to update minors
-numpy>=1.17,<1.17.99
-pandas>=0.25.1,<0.25.99
-pangres>=2.1,<2.99
+numpy==1.19.1
+pandas==1.0.5
+pangres==2.1
 
-requests>=2.22,<2.22.99
-pyOpenSSL>=19.0,<19.0.99
-canvasapi>=0.10,<0.10.99
-protobuf>=3.10.0,<3.10.99
+pyOpenSSL==19.1.0
+protobuf==3.12.2
 
 # These caused problems in the past so test when updating
 djangosaml2==0.19.1
 pysaml2==5.1.0
 
-SQLAlchemy>=1.3.10,<1.3.99
+SQLAlchemy==1.3.18
 psycopg2==2.8.5
 mysqlclient==1.4.6
-google-cloud-bigquery>=1.21.0,<1.21.99
+google-cloud-bigquery==1.26.0
 
-pinax-eventlog>=2.0.3,<2.0.99
-ptvsd>=4.3.2,<4.3.99
+pinax-eventlog==2.0.3
+ptvsd==4.3.2
 django-ptvsd-debug==1.0.3
+django-lti-auth==1.0.0
 PyLTI1p3==1.7.0
 django-webpack-loader==0.6.0
+django-csp==3.5
+
 jsonschema==3.2.0
-django-csp==3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-mysql==3.7.1
 promise==2.2.1
 
 # graphql
-graphene-django>=2.8.0,<2.8.99
+graphene-django>=2.12.1,<2.12.99
 django-filter>=2.2.0,<2.2.99
 
 # object-level permissions


### PR DESCRIPTION
This PR aims to resolve #952. This PR has dependency on this [PR](https://github.com/tl-its-umich-edu/my-learning-analytics/pull/997) related to Graphene-django update


As part of LTI 1.3 update Django version is updated to 3. But this PR is aiming to update all the latest version pip package.


Certain packages don't have an update since couple of years. I feel either we have to revisit then for alternatives

Pinax-eventlog library had an latest release of 4.0.1 and update to that break for Mysql as migration file is incorrect for mysql more on that [here](https://github.com/pinax/pinax-eventlog/issues/32).