### PR TITLE
#826 - load MiVideo usage data from UDP

### DIFF
--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -207,6 +207,7 @@
                 "SELECT 'canvas' AS resource_type, ",
                 "CAST(SUBSTR(JSON_EXTRACT_SCALAR(event, '$.object.id'), 35) AS STRING) AS resource_id, ",
                 "CAST(SUBSTR(JSON_EXTRACT_SCALAR(event, '$.membership.member.id'), 29) AS INT64) AS user_id, ",
+                "cast(null as string) AS user_login_name,",
                 "CAST(SUBSTR(JSON_EXTRACT_SCALAR(event, '$.group.id'), 31) AS INT64) AS course_id, ",
                 "COALESCE(",
                 "JSON_EXTRACT_SCALAR(event, '$.object.extensions[\\'com.instructure.canvas\\'].asset_name'), ",
@@ -233,6 +234,7 @@
                 "select 'leccap' AS resource_type, ",
                 "CAST(SUBSTR(JSON_EXTRACT_SCALAR(event, '$.object.id'), 48) AS STRING) AS resource_id, ",
                 "@canvas_data_id_increment + CAST(JSON_EXTRACT_SCALAR(event, '$.federatedSession.messageParameters.custom_canvas_user_id') AS INT64) AS user_id, ",
+                "cast(null as string) AS user_login_name,",
                 "@canvas_data_id_increment + CAST(JSON_EXTRACT_SCALAR(event, '$.federatedSession.messageParameters.custom_canvas_course_id') AS INT64) AS course_id, ",
                 "JSON_EXTRACT_SCALAR(event, '$.object.name') as name, ",
                 "datetime(EVENT_TIME) as access_time ",
@@ -251,6 +253,7 @@
             "query": [
                 "SELECT 'mivideo' AS resource_type,",
                 "replace(JSON_EXTRACT_SCALAR(event, '$.object.id'), 'https://aakaf.mivideo.it.umich.edu/caliper/info/media/', '') AS resource_id,",
+                "cast(-1 as INT64) AS user_id,",
                 "replace(JSON_EXTRACT_SCALAR(event, '$.actor.id'), 'https://aakaf.mivideo.it.umich.edu/caliper/info/user/', '') AS user_login_name,",
                 "@canvas_data_id_increment + CAST(JSON_EXTRACT_SCALAR(event, '$.object.extensions.kaf:course_id') AS INT64) AS course_id,",
                 "JSON_EXTRACT_SCALAR(event, '$.object.name') AS name,",

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -259,7 +259,7 @@
                 "JSON_EXTRACT_SCALAR(event, '$.object.name') AS name,",
                 "datetime(EVENT_TIME) AS access_time",
                 "FROM event_store.events WHERE",
-                "(JSON_EXTRACT_SCALAR(event, '$.edApp') = 'https://aakaf.mivideo.it.umich.edu/caliper/info/app/KafEdApp' OR JSON_EXTRACT_SCALAR(event, '$.edApp.id') = 'https://aakaf.mivideo.it.umich.edu/caliper/info/app/KafEdApp')",
+                "COALESCE(JSON_EXTRACT_SCALAR(event, '$.edApp.id'), JSON_EXTRACT_SCALAR(event, '$.edApp')) = 'https://aakaf.mivideo.it.umich.edu/caliper/info/app/KafEdApp'",
                 "AND TYPE = 'MediaEvent'",
                 "AND JSON_EXTRACT_SCALAR(event, '$.action') = 'Started'",
                 "AND JSON_EXTRACT_SCALAR(event, '$.object.extensions.kaf:course_id') IN UNNEST(@course_ids_short)"

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -246,6 +246,25 @@
             "/* mention if the caliper event data is providing long or short canvas id and change the query to store long id as in this case": "*/",
             "canvas_course_id_format": "SHORT",
             "urls": {"prefix": "https://leccap.engin.umich.edu/leccap/viewer/r/", "postfix": ""}
+        },
+        "mivideo": {
+            "query": [
+                "SELECT 'mivideo' AS resource_type,",
+                "replace(JSON_EXTRACT_SCALAR(event, '$.object.id'), 'https://aakaf.mivideo.it.umich.edu/caliper/info/media/', '') AS resource_id,",
+                "replace(JSON_EXTRACT_SCALAR(event, '$.actor.id'), 'https://aakaf.mivideo.it.umich.edu/caliper/info/user/', '') AS user_login_name,",
+                "@canvas_data_id_increment + CAST(JSON_EXTRACT_SCALAR(event, '$.object.extensions.kaf:course_id') AS INT64) AS course_id,",
+                "JSON_EXTRACT_SCALAR(event, '$.object.name') AS name,",
+                "datetime(EVENT_TIME) AS access_time",
+                "FROM event_store.events WHERE",
+                "(JSON_EXTRACT_SCALAR(event, '$.edApp') = 'https://aakaf.mivideo.it.umich.edu/caliper/info/app/KafEdApp' OR JSON_EXTRACT_SCALAR(event, '$.edApp.id') = 'https://aakaf.mivideo.it.umich.edu/caliper/info/app/KafEdApp')",
+                "AND TYPE = 'MediaEvent'",
+                "AND JSON_EXTRACT_SCALAR(event, '$.action') = 'Started'",
+                "AND JSON_EXTRACT_SCALAR(event, '$.object.extensions.kaf:course_id') IN UNNEST(@course_ids_short)"
+            ],
+            "app_display_name": "MiVideo",
+            "/* mention if the caliper event data is providing long or short canvas id and change the query to store long id as in this case": "*/",
+            "canvas_course_id_format": "SHORT",
+            "urls": {"prefix": "https://aakaf.mivideo.it.umich.edu/caliper/info/media/", "postfix": ""}
         }
     },
     "/* Disable/Enable courses_enabled api": "*/",

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -11,7 +11,6 @@ from django.db import connections as conns, models
 from django.db.models import QuerySet
 from django_cron import CronJobBase, Schedule
 from google.cloud import bigquery
-from pandas import DataFrame
 from sqlalchemy import create_engine, types
 
 from dashboard.common import db_util, utils
@@ -292,7 +291,7 @@ class DashboardCronJob(CronJobBase):
             # Location must match that of the dataset(s) referenced in the query.
             bq_query = bigquery_client.query(final_bq_query, location='US', job_config=job_config)
 
-            resource_access_df: DataFrame = bq_query.to_dataframe()
+            resource_access_df: pd.DataFrame = bq_query.to_dataframe()
             total_bytes_billed += bq_query.total_bytes_billed
 
             resource_access_row_count = len(resource_access_df)

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -566,12 +566,12 @@ class DashboardCronJob(CronJobBase):
             logger.info("** user")
             status += self.update_user()
 
-            # logger.info("** assignment")
-            # status += self.update_groups()
-            # status += self.update_assignment()
-            #
-            # status += self.submission()
-            # status += self.weight_consideration()
+            logger.info("** assignment")
+            status += self.update_groups()
+            status += self.update_assignment()
+
+            status += self.submission()
+            status += self.weight_consideration()
 
             logger.info("** resources")
             if 'show_resources_accessed' not in settings.VIEWS_DISABLED:

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -396,6 +396,7 @@ class DashboardCronJob(CronJobBase):
                 dtype = {'resource_id': types.VARCHAR(255)}
                 pangres.upsert(engine=engine, df=resource_df,
                                table_name='resource', if_row_exists='update',
+                               create_schema=False, add_new_columns=False,
                                dtype=dtype)
             except Exception as e:
                 logger.exception('Error running upsert on table resource')

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -295,7 +295,11 @@ class DashboardCronJob(CronJobBase):
             resource_access_df: DataFrame = bq_query.to_dataframe()
             total_bytes_billed += bq_query.total_bytes_billed
 
-            logger.debug("df row number=" + str(resource_access_df.shape[0]))
+            logger.debug(f'resource_access_df row count: ({len(resource_access_df)})')
+
+            if len(resource_access_df) == 0:
+                logger.info('No resource access data found.  Continuing...')
+                continue
 
             # for data which contains user login names, not IDs
             if (('user_login_name' in resource_access_df.columns)
@@ -315,7 +319,7 @@ class DashboardCronJob(CronJobBase):
             # drop duplicates
             resource_access_df = resource_access_df.drop_duplicates(["resource_id", "user_id", "access_time"], keep='first')
 
-            logger.debug("after drop duplicates, df row number=" + str(resource_access_df.shape[0]))
+            logger.debug(f'resource_access_df row count (de-duped): ({len(resource_access_df)})')
 
             logger.debug(resource_access_df)
 


### PR DESCRIPTION
Resolves #826.

I scrapped the approach I had been taking and started fresh.

Rather than trying to combine UDP and Kaltura API data using a new technique of my own, I decided to re-use the existing UDP-only approach and adapt it to work with MiVideo events.  The efficiency I thought my technique would bring probably wouldn't save as much resources as I expected.

The strange thing about this when I test it is that I see many messages logged to the console that say rows with various resource names and IDs are being updated, but when the process is done and I check my DB contents, I don't see any of that.

~Also, I've been testing with my personal test course in production Canvas (https://umich.instructure.com/courses/374350).  The course has several test students and they've all viewed the MiVideo content I published.  I can see Caliper events from their activity in production UDP.  However, those users are never added to the `user` table of my DB.  The cron code isn't doing what I expect.  I've probably misunderstood some of the subtleties of the process.~

UDW delays were a problem when it came to testing.  I'd added new students to my course to test with and it seemed to take more than 24 hours for those students to appear in the UDW course roster.

## Caveat

I'm having trouble testing the MyLA UI for this change.  This code gets the MiVideo data into the DB, but I've not actually seen it in the UI, either via LTI or SAML launch.  I'm still working on verifying that the resources are shown for courses, but I'd appreciate tips to get that working.