### PR TITLE
Fix current mypy issues in dashboard (#1027)

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from django import forms
 from django.conf import settings
 from django.contrib import admin
@@ -25,7 +27,7 @@ class CourseViewOptionInline(admin.StackedInline):
     model = CourseViewOption
     form = AlwaysChangedModelForm
 
-    exclude = ()
+    exclude: Tuple[str, ...] = ()
 
     # exclude disabled views
     for view in CourseViewOption.VIEWS:
@@ -65,7 +67,9 @@ class CourseAdmin(admin.ModelAdmin):
     # Need this method to correctly display the line breaks
     def _courseviewoption(self, obj):
         return mark_safe(linebreaksbr(obj.courseviewoption))
-    _courseviewoption.short_description = "Course View Option(s)"
+
+    # Known mypy issue: https://github.com/python/mypy/issues/708
+    _courseviewoption.short_description = "Course View Option(s)" # type: ignore[attr-defined]
 
     def course_link(self, obj):
         return format_html('<a href="{}">Link</a>', obj.absolute_url)

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -1,12 +1,15 @@
 # Some utility functions used by other classes in this project
 import logging
 from datetime import datetime
-from typing import Dict, List, Union
+from typing import Any, Dict, List, TypedDict, Union
+
 from dateutil.parser import parse
 import django
-from django_cron.models import CronJobLog
-from dashboard.models import Course, User
 from django.conf import settings
+from django_cron.models import CronJobLog
+
+from dashboard.models import Course, User
+
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +87,13 @@ def get_default_user_course_id(user_id):
     return course_id
 
 
-def get_user_courses_info(username: str, course_id=None) -> List[Dict[str, Union[str, int, List[str]]]]:
+class CourseEnrollment(TypedDict):
+    course_id: int
+    course_name: str
+    enrollment_types: List[str]
+
+
+def get_user_courses_info(username: str, course_id: Union[int, None] = None) -> List[CourseEnrollment]:
     """
     Fetching the user courses enrollment info, for standalone it will return all the courses enrollment for LTI
     single course enrollment info
@@ -94,7 +103,7 @@ def get_user_courses_info(username: str, course_id=None) -> List[Dict[str, Union
     :return: [{`course_id`: 1233, `course_name`: 'COURSES WN 2020', `enrollment_types`: ['StudentEnrollment'] }]
     """
     logger.info(get_user_courses_info.__name__)
-    course_enrollments: Dict[int, Dict[str, Union[int, str, List[str]]]] = {}
+    course_enrollments: Dict[int, CourseEnrollment] = {}
     if course_id:
         user_enrollments = User.objects.filter(course_id=canvas_id_to_incremented_id(course_id),
                                                sis_name=username)

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -1,6 +1,6 @@
 import datetime, logging
 from collections import namedtuple
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import pandas as pd
 import pytz
@@ -559,7 +559,7 @@ class DashboardCronJob(CronJobBase):
 
         for course in courses:
             updated_fields: List[str] = []
-            warehouse_course_dict: Dict[str, any] = warehouse_courses_data.loc[warehouse_courses_data['id'] == course.id].iloc[0].to_dict()
+            warehouse_course_dict: Dict[str, Any] = warehouse_courses_data.loc[warehouse_courses_data['id'] == course.id].iloc[0].to_dict()
 
             warehouse_course_name: str = warehouse_course_dict['name']
             if course.name != warehouse_course_name:

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -10,8 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
-import os
-import json
+import json, os
+from typing import Tuple, Union
 
 from debug_toolbar import settings as dt_settings
 from django.utils.module_loading import import_string
@@ -25,9 +25,10 @@ PROJECT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), ".."),
 )
 
-if os.getenv("ENV_JSON"):
+env_json: Union[str, None] = os.getenv('ENV_JSON')
+if env_json:
     # optionally load settings from an environment variable
-    ENV = json.loads(os.getenv("ENV_JSON"))
+    ENV = json.loads(env_json)
 else:
     # else try loading settings from the json config file
     try:
@@ -318,7 +319,7 @@ try:
 except ImportError:
     pass
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS: Tuple[str, ...] = (
     'rules.permissions.ObjectPermissionBackend',
     'django_su.backends.SuBackend',
 )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+python_version = 3.8


### PR DESCRIPTION
This PR adds a `mypy.ini` file specifying the Python 3.8 version and fixes mypy errors currently flagged by running `mypy` on the command line. An error flagged in a migration file was ignored. This PR aims to resolve issue #1027.