### PR TITLE
Fixes #1034 - Enable pylint to catch errors and fatal issues.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "python.linting.mypyEnabled": true,
     "[javascript]": {
         "editor.tabSize": 2
-    }
+    },
+    "editor.formatOnSaveMode": "modifications"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,12 @@
 {
-    "python.linting.pylintArgs": ["--load-plugins=pylint_django"],
     "python.linting.enabled": true,
-    "python.linting.pylintEnabled": false,
+    "python.linting.pylintEnabled": true,
+    "python.linting.pylintArgs": [
+        "--disable=C0111", // missing docstring
+        "--load-plugins=pylint_django",
+        "--disable=all",
+        "--enable=F,E" // Only enable errors for now, will turn on warnings in a future fix
+    ],
     "python.linting.flake8Enabled": false,
     "python.linting.mypyEnabled": true,
     "[javascript]": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,6 @@ django-csp==3.6
 
 jwcrypto==0.8
 pycryptodome==3.9.8
+# These are for local development
+pylint==2.5.3
+pylint-django==2.3.0


### PR DESCRIPTION
Currently disabled for any lower messages like warnings as there are many in the code. Maybe we want these on but really need to see the errors.