### PR TITLE
Lock list of course IDs driving other cron methods after verification (#1062)

### DIFF
--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -611,9 +611,6 @@ class DashboardCronJob(CronJobBase):
 
         # Lock in valid course IDs that data will be pulled for.
         course_df: pd.DataFrame = course_verification.course_data
-        # It not be a best practice to set instance variables in a method, but seemed less messy than overriding the __init__
-        # from CronJobBase. See https://stackoverflow.com/questions/19284857/instance-attribute-attribute-name-defined-outside-init
-        # I'll probably look into this more later. - Sam
         self.valid_locked_course_ids: List[int] = course_df['id'].to_list()
 
         # continue cron tasks

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -143,7 +143,7 @@ class DashboardCronJob(CronJobBase):
             courses_data = pd.concat(course_dfs).reset_index()
         else:
             logger.info("No course records were found in the database.")
-            courses_data = pd.DataFrame()
+            courses_data = pd.DataFrame(columns=["id", "canvas_id", "enrollment_term_id", "name", "start_at", "conclude_at"])
 
         CourseVerification = namedtuple("CourseVerification", ["invalid_course_ids", "course_data"])
         return CourseVerification(invalid_course_id_list, courses_data)
@@ -615,10 +615,8 @@ class DashboardCronJob(CronJobBase):
             return (status,)
 
         # Lock in valid course IDs that data will be pulled for.
-        if not course_verification.course_data.empty:
-            self.valid_locked_course_ids = course_verification.course_data['id'].to_list()
-        else:
-            self.valid_locked_course_ids = []
+        self.valid_locked_course_ids = course_verification.course_data['id'].to_list()
+        logger.info(f'Valid locked course IDs: {self.valid_locked_course_ids}')
 
         # continue cron tasks
 

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -615,7 +615,10 @@ class DashboardCronJob(CronJobBase):
             return (status,)
 
         # Lock in valid course IDs that data will be pulled for.
-        self.valid_locked_course_ids = course_verification.course_data['id'].to_list()
+        if not course_verification.course_data.empty:
+            self.valid_locked_course_ids = course_verification.course_data['id'].to_list()
+        else:
+            self.valid_locked_course_ids = []
 
         # continue cron tasks
 

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -113,7 +113,6 @@ class DashboardCronJob(CronJobBase):
         super().__init__()
         self.valid_locked_course_ids: List[int]
 
-
     # verify whether course ids are valid
     def verify_course_ids(self):
         # whether all course ids are valid ids


### PR DESCRIPTION
This PR creates a new instance variable on `DashboardCronJob` that is used for storing the course IDs verified by the initial `verify_course_ids` method. This variable is then used in lieu of `Course.objects.get_supported_courses`, because this list is static (while users could add new courses during the cron run, which would be returned by `get_supported_courses` or other `QuerySet` at other points of the run). The PR aims to resolve issue #1062.