### PR TITLE
add key generation management command (#1066)

### DIFF
--- a/dashboard/management/commands/createkeys.py
+++ b/dashboard/management/commands/createkeys.py
@@ -1,0 +1,46 @@
+import json
+import os
+import shutil
+
+from Crypto.PublicKey import RSA
+from django.core.management.base import BaseCommand
+from jwcrypto.jwk import JWK
+from jwt.utils import merge_dict
+
+
+class Command(BaseCommand):
+    private_key_suffix = '-private.pem'
+    public_key_suffix = '-public.pem'
+    jwk_suffix = '-public-jwk.json'
+
+    def handle(self, *args, **options):
+        config_dir = os.path.dirname(os.getenv('ENV_FILE', '/secrets/env.json'))
+        self.stdout.write(f'Key files written to directory "{config_dir}"...')
+
+        self.stdout.write('Generating key...')
+        key = RSA.generate(4096)
+
+        self.stdout.write('Preparing private and public key strings...')
+        private_key = key.exportKey()
+        public_key = key.publickey().exportKey()
+
+        self.stdout.write(
+            f'Writing private key to file "{self.private_key_suffix}"...')
+        with open(self.private_key_suffix, 'w') as f:
+            f.writelines((private_key.decode('utf-8'), '\n'))
+
+        self.stdout.write(
+            f'Writing public key to file "{self.public_key_suffix}"...')
+        with open(self.public_key_suffix, 'w') as f:
+            f.writelines((public_key.decode('utf-8'), '\n'))
+
+        jwk_obj = JWK.from_pem(public_key)
+        public_jwk = {
+            **json.loads(jwk_obj.export_public()),
+            **{'alg': 'RS256', 'use': 'sig'}
+        }
+
+        self.stdout.write(
+            f'Writing JWK to file "{self.jwk_suffix}"...')
+        with open(self.jwk_suffix, 'w') as f:
+            f.writelines((json.dumps(public_jwk), '\n'))

--- a/dashboard/management/commands/createkeys.py
+++ b/dashboard/management/commands/createkeys.py
@@ -27,7 +27,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options: dict):
         configDir = os.path.dirname(os.getenv('ENV_FILE', '/secrets/env.json'))
-        self.stdout.write(f'Key files written to directory "{configDir}"...')
+        self.stdout.write('Key files will be written to '
+                          f'directory "{configDir}"...')
 
         keyFileBasePathName = os.path.join(
             configDir, options.get(self.baseNameOption))

--- a/dashboard/management/commands/createkeys.py
+++ b/dashboard/management/commands/createkeys.py
@@ -15,22 +15,22 @@ class Command(BaseCommand):
     timestampFormat = '%Y%m%d%H%M%S'
 
     def add_arguments(self, parser: CommandParser):
-        parser.add_argument(f'--{self.baseNameOption}',
-                            dest=self.baseNameOption, type=str, required=False,
-                            help='Base file name of the key files generated.  '
-                                 'Default: timestamp of '
-                                 f'"{self.timestampFormat.replace("%", "%%")}"'
-                            )
+        parser.add_argument(
+            f'--{self.baseNameOption}',
+            default=datetime.now().strftime(self.timestampFormat),
+            type=str,
+            required=False,
+            help='Base file name of the key files generated. Default: '
+                 f'timestamp of "{self.timestampFormat.replace("%", "%%")}"',
+            dest=self.baseNameOption)
 
 
     def handle(self, *args, **options: dict):
         configDir = os.path.dirname(os.getenv('ENV_FILE', '/secrets/env.json'))
         self.stdout.write(f'Key files written to directory "{configDir}"...')
 
-        baseName = options.get(self.baseNameOption)
-        if not baseName:
-            baseName = datetime.now().strftime(self.timestampFormat)
-        keyFileBasePathName = os.path.join(configDir, baseName)
+        keyFileBasePathName = os.path.join(
+            configDir, options.get(self.baseNameOption))
 
         self.stdout.write('Generating key...')
         key = RSA.generate(4096)

--- a/dashboard/management/commands/createkeys.py
+++ b/dashboard/management/commands/createkeys.py
@@ -1,18 +1,27 @@
 import json
 import os
 from datetime import datetime
+from enum import Enum
 
 from Crypto.PublicKey import RSA
+from Crypto.PublicKey.RSA import RsaKey
 from django.core.management.base import BaseCommand, CommandParser
 from jwcrypto.jwk import JWK
 
 
 class Command(BaseCommand):
-    privateKeyFileSuffix = '_private.pem'
-    publicKeyFileSuffix = '_public.pem'
-    jwkFileSuffix = '_public-jwk.json'
     baseNameOption = 'basename'
     timestampFormat = '%Y%m%d%H%M%S'
+    _keyFileBasePathName: str
+
+    class KeyFileType(Enum):
+        JWK = ('JWK', '_public-jwk.json')
+        PRIVATE = ('private key', '_private.pem')
+        PUBLIC = ('public key', '_public.pem')
+
+        def __init__(self, description, fileSuffix):
+            self.description = description
+            self.fileSuffix = fileSuffix
 
     def add_arguments(self, parser: CommandParser):
         parser.add_argument(
@@ -24,41 +33,51 @@ class Command(BaseCommand):
                  f'timestamp of "{self.timestampFormat.replace("%", "%%")}"',
             dest=self.baseNameOption)
 
+    def _writeKeyFile(self, keyFileType: KeyFileType, keyContent: str):
+        keyFileName: str = f'{self.keyFileBasePathName}' \
+                           f'{keyFileType.fileSuffix}'
+        self.stdout.write(
+            f'Writing {keyFileType.description} to file '
+            f'"{keyFileName}"...')
+        with open(keyFileName, 'w') as f:
+            f.writelines((keyContent, '\n'))
+        self.stdout.write('File successfully written.')
+
+    @property
+    def keyFileBasePathName(self):
+        return self._keyFileBasePathName
+
+    @keyFileBasePathName.setter
+    def keyFileBasePathName(self, value: str):
+        self._keyFileBasePathName = value
+
     def handle(self, *args, **options: dict):
-        configDir = os.path.dirname(os.getenv('ENV_FILE', '/secrets/env.json'))
+        configDir: str = os.path.dirname(
+            os.getenv('ENV_FILE', '/secrets/env.json'))
         self.stdout.write('Key files will be written to '
                           f'directory "{configDir}"...')
 
-        keyFileBasePathName = os.path.join(
+        self.keyFileBasePathName = os.path.join(
             configDir, options.get(self.baseNameOption))
 
         self.stdout.write('Generating key...')
-        key = RSA.generate(4096)
+        key: RsaKey = RSA.generate(4096)
 
         self.stdout.write('Preparing private and public key strings...')
-        privateKey = key.exportKey()
-        publicKey = key.publickey().exportKey()
+        privateKey: bytes = key.exportKey()
+        publicKey: bytes = key.publickey().exportKey()
 
-        privateKeyFileName = f'{keyFileBasePathName}{self.privateKeyFileSuffix}'
-        self.stdout.write(
-            f'Writing private key to file "{privateKeyFileName}"...')
-        with open(privateKeyFileName, 'w') as f:
-            f.writelines((privateKey.decode('utf-8'), '\n'))
-
-        publicKeyFileName = f'{keyFileBasePathName}{self.publicKeyFileSuffix}'
-        self.stdout.write(
-            f'Writing public key to file "{publicKeyFileName}"...')
-        with open(publicKeyFileName, 'w') as f:
-            f.writelines((publicKey.decode('utf-8'), '\n'))
-
-        jwk_obj = JWK.from_pem(publicKey)
-        public_jwk = {
+        jwk_obj: JWK = JWK.from_pem(publicKey)
+        public_jwk: dict = {
             **json.loads(jwk_obj.export_public()),
             **{'alg': 'RS256', 'use': 'sig'}
         }
 
-        jwkFileName = f'{keyFileBasePathName}{self.jwkFileSuffix}'
-        self.stdout.write(
-            f'Writing JWK to file "{jwkFileName}"...')
-        with open(jwkFileName, 'w') as f:
-            f.writelines((json.dumps(public_jwk), '\n'))
+        self._writeKeyFile(self.KeyFileType.PRIVATE,
+                           privateKey.decode('utf-8'))
+
+        self._writeKeyFile(self.KeyFileType.PUBLIC,
+                           publicKey.decode('utf-8'))
+
+        self._writeKeyFile(self.KeyFileType.JWK,
+                           json.dumps(public_jwk))

--- a/dashboard/management/commands/createkeys.py
+++ b/dashboard/management/commands/createkeys.py
@@ -24,7 +24,6 @@ class Command(BaseCommand):
                  f'timestamp of "{self.timestampFormat.replace("%", "%%")}"',
             dest=self.baseNameOption)
 
-
     def handle(self, *args, **options: dict):
         configDir = os.path.dirname(os.getenv('ENV_FILE', '/secrets/env.json'))
         self.stdout.write('Key files will be written to '

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,6 @@ PyLTI1p3==1.7.0
 django-webpack-loader==0.6.0
 jsonschema==3.2.0
 django-csp==3.6
+
+jwcrypto==0.8
+pycryptodome==3.9.8


### PR DESCRIPTION
Resolves #1066.

Adds `createkeys` command to Django management tools.  Includes a `--basename` option to allow the user to specify a name for the key files generated.  If no base name is specified, a timestamp of the format `%Y%m%d%H%M%S` is used by default.  It produces three key files in the configuration directory, with the suffixes `_private.pem`, `_public.pem`, and `_public-jwk.json`.

## Example

When called as:

```sh
python manage.py createkeys --basename tarfu
```

It produces files named `tarfu_private.pem`, `tarfu_public.pem`, and `tarfu_public-jwk.json`.