### PR TITLE
issue-1070: operate on dataframe copy to prevent Pandas SettingWithCopyWarning warning

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -588,11 +588,11 @@ def assignments(request, course_id=0):
     assignment_data['progress'] = json.loads(df_progressbar.to_json(orient='records'))
 
     # Group the data according the assignment prep view
-    df_greaterthan_percent = df.loc[df['towards_final_grade'] >= percent_selection].copy()
-    df_greaterthan_percent.reset_index(inplace=True)
-    df_greaterthan_percent.drop(columns=['index'], inplace=True)
-    logger.debug('The Dataframe for the assignment planning %s ' % df_greaterthan_percent)
-    grouped = df_greaterthan_percent.groupby(['week', 'due_dates'])
+    df_plan = df.loc[df['towards_final_grade'] >= percent_selection].copy()
+    df_plan.reset_index(inplace=True)
+    df_plan.drop(columns=['index'], inplace=True)
+    logger.debug('The Dataframe for the assignment planning %s ' % df_plan)
+    grouped = df_plan.groupby(['week', 'due_dates'])
 
     assignment_list = []
     for name, group in grouped:

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -575,6 +575,8 @@ def assignments(request, course_id=0):
     df['avg_score']=df['avg_score'].fillna('Not available')
 
     df3 = df[df['towards_final_grade'] > 0.0]
+    # operate on dataframe copy to prevent Pandas "SettingWithCopyWarning" warning
+    df3 = df3.copy()
     df3[['score']] = df3[['score']].astype(float)
     df3['graded'] = df3['graded'].fillna(False)
     df3[['score']] = df3[['score']].astype(float)


### PR DESCRIPTION
Without the fix, I can repeat the problem by going to MyLA courses and open Assignment Planning view.

The SettingWithCopyWarning is a type of Pandas warning message, and [there are ways to fix the warning](https://www.dataquest.io/blog/settingwithcopywarning/). This fix is to get a copy of dataframe object first before further operations. 