### PR TITLE
Add alt text for mouse on wheel loading image (#1082)

### DIFF
--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -67,7 +67,11 @@ function Course (props) {
             {courseInfo.course_data_loaded === 0
               ? (
                 <Card className={classes.card}>
-                  <CardMedia className={classes.media} image='/static/images/no-course-data-msg.png' />
+                  <CardMedia
+                    className={classes.media}
+                    image='/static/images/no-course-data-msg.png'
+                    title='Mouse running on wheel with text "course data being processed Try back in 24 hours"'
+                  />
                 </Card>
               ) : (
                 <>


### PR DESCRIPTION
Set alt text via title on CardMedia element.

I tested using the [ChromeVox](https://chrome.google.com/webstore/detail/chromevox-classic-extensi/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en) chrome extension.

By default I (Windows) had to press Shift+Alt+A Shift+Alt+A to toggle ChromeVox on and off.  Shift+Alt is the "Chrome Vox Key" and is different on different platforms. On MacOS its Control+Command, per the documentation.

Navigating to the image (I clicked on it) triggers the text to be read aloud.