### PR TITLE
Update title when navigating site

### DIFF
--- a/assets/src/containers/App.js
+++ b/assets/src/containers/App.js
@@ -5,6 +5,7 @@ import GoogleAnalyticsTracking from '../components/GoogleAnalyticsTracking'
 import CourseList from './CourseList'
 import Course from './Course'
 import WarningBanner from '../components/WarningBanner'
+import { Helmet } from 'react-helmet'
 
 function App (props) {
   const { location, user, gaId } = props
@@ -20,6 +21,7 @@ function App (props) {
 
   return (
     <>
+      <Helmet titleTemplate='%s | My Learning Analytics' title='Courses' />
       <GoogleAnalyticsTracking gaId={gaId} />
       <Route path='/' exact render={props => <CourseList {...props} user={user} />} />
       <Route path='/courses' exact render={props => <CourseList {...props} user={user} />} />

--- a/assets/src/containers/AssignmentPlanning.js
+++ b/assets/src/containers/AssignmentPlanning.js
@@ -21,6 +21,7 @@ import { useAssignmentData } from '../service/api'
 import { getCurrentWeek } from '../util/data'
 import { isObjectEmpty } from '../util/object'
 import { isTeacherOrAdmin } from '../util/roles'
+import { Helmet } from 'react-helmet'
 
 const styles = theme => ({
   root: {
@@ -135,6 +136,7 @@ function AssignmentPlanning (props) {
 
   return (
     <>
+      <Helmet title='Assignment Planning' />
       {disabled ? <AlertBanner>Preview Mode: This view is currently disabled for students.</AlertBanner> : undefined}
       <div className={classes.root}>
         <Grid container spacing={2}>

--- a/assets/src/containers/AssignmentPlanningV2.js
+++ b/assets/src/containers/AssignmentPlanningV2.js
@@ -18,6 +18,7 @@ import useSaveUserSetting from '../hooks/useSaveUserSetting'
 import useSyncAssignmentAndGoalGrade from '../hooks/useSyncAssignmentAndGoalGrade'
 import useUserAssignmentSetting from '../hooks/useUserAssignmentSetting'
 import { isTeacherOrAdmin } from '../util/roles'
+import { Helmet } from 'react-helmet'
 
 import {
   clearGoals,
@@ -129,6 +130,7 @@ function AssignmentPlanningV2 (props) {
 
   return (
     <>
+      <Helmet title='Assignment Planning' />
       {disabled ? <AlertBanner>Preview Mode: This view is currently disabled for students.</AlertBanner> : undefined}
       <div className={classes.root}>
         <Grid container spacing={2}>

--- a/assets/src/containers/Course.js
+++ b/assets/src/containers/Course.js
@@ -13,6 +13,7 @@ import { useCourseInfo } from '../service/api'
 import WarningBanner from '../components/WarningBanner'
 import { CardMedia, Card } from '@material-ui/core'
 import { withStyles } from '@material-ui/core/styles'
+import { Helmet } from 'react-helmet'
 
 const styles = theme => ({
   card: {
@@ -54,6 +55,7 @@ function Course (props) {
       {loaded
         ? (
           <>
+            <Helmet titleTemplate='%s | My Learning Analytics' title={courseInfo.name} />
             <DashboardAppBar
               onMenuBarClick={toggleDrawer}
               sideDrawerState={sideDrawerState}

--- a/assets/src/containers/GradeDistribution.js
+++ b/assets/src/containers/GradeDistribution.js
@@ -17,6 +17,7 @@ import { isObjectEmpty } from '../util/object'
 import useSetUserSetting from '../hooks/useSetUserSetting'
 import useUserSetting from '../hooks/useUserSetting'
 import { isTeacherOrAdmin } from '../util/roles'
+import { Helmet } from 'react-helmet'
 
 const styles = theme => ({
   root: {
@@ -131,6 +132,7 @@ function GradeDistribution (props) {
 
   return (
     <>
+      <Helmet title='Grade Distribution' />
       {disabled ? <AlertBanner>Preview Mode: This view is currently disabled for students.</AlertBanner> : undefined}
       <div className={classes.root}>
         <Grid container spacing={2}>

--- a/assets/src/containers/ResourcesAccessed.js
+++ b/assets/src/containers/ResourcesAccessed.js
@@ -22,6 +22,7 @@ import useUserSetting from '../hooks/useUserSetting'
 import { isObjectEmpty } from '../util/object'
 import { handleError, defaultFetchOptions } from '../util/data'
 import { isTeacherOrAdmin } from '../util/roles'
+import { Helmet } from 'react-helmet'
 
 const styles = theme => ({
   root: {
@@ -233,6 +234,7 @@ function ResourcesAccessed (props) {
   }
   return (
     <>
+      <Helmet title='Resources Accessed' />
       {disabled ? <AlertBanner>Preview Mode: This view is currently disabled for students.</AlertBanner> : undefined}
       <div className={classes.root}>
         <Grid container spacing={2}>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "jquery": ">=3.4.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
-    "rc-slider": "^8.7.1"
+    "rc-slider": "^8.7.1",
+    "react-helmet": "^6.1.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Closes #957 

This might turn out to be irrelevant with changes for LTI but leaving this PR here in case.

This updates the title when you brows between courses/course/view in standalone mode, but does not change the title in LTI mode (at least in the case of Canvas, where it remains the LTI tool's name.)