### PR TITLE
Elimiate an unnecessary warning message for admins

### DIFF
--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -94,13 +94,15 @@ class CourseEnrollment(TypedDict):
     enrollment_types: List[str]
 
 def is_superuser(user_name: str) -> bool:
-    logger.info(is_superuser.__name__+f' \'{user_name}\'')
+    logger.debug(is_superuser.__name__+f' \'{user_name}\'')
 
     user = DjangoUser.objects.filter(username=user_name)
     if user.count() == 0:
-        return False
+        result = False
     else:
-        return user[0].is_superuser
+        result = user[0].is_superuser
+    logger.debug(is_superuser.__name__+f' \'{user_name}\':{result}')
+    return result
 
 def get_user_courses_info(username: str, course_id: Union[int, None] = None) -> List[CourseEnrollment]:
     """

--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -10,6 +10,7 @@ from django_cron.models import CronJobLog
 
 from dashboard.models import Course, User
 
+from django.contrib.auth.models import User as DjangoUser
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,14 @@ class CourseEnrollment(TypedDict):
     course_name: str
     enrollment_types: List[str]
 
+def is_superuser(user_name: str) -> bool:
+    logger.info(is_superuser.__name__+f' \'{user_name}\'')
+
+    user = DjangoUser.objects.filter(username=user_name)
+    if user.count() == 0:
+        return False
+    else:
+        return user[0].is_superuser
 
 def get_user_courses_info(username: str, course_id: Union[int, None] = None) -> List[CourseEnrollment]:
     """
@@ -110,8 +119,9 @@ def get_user_courses_info(username: str, course_id: Union[int, None] = None) -> 
     else:
         user_enrollments = User.objects.filter(sis_name=username)
     if user_enrollments.count() == 0:
-        logger.warning(
-            f'Couldn\'t find user {username} in enrollment info. The user could be an admin, or enrollment data has not been populated yet.')
+        if not is_superuser(username):
+            logger.warning(
+                f'Couldn\'t find user {username} in enrollment info. Enrollment data has not been populated yet.')
         return []
 
     for enrollment in user_enrollments:


### PR DESCRIPTION
Closes #1061 

This eliminates a warning message for admin users.

I believe this situation can only occur in standalone.