### PR TITLE
Implement LTI config by URL (#1054)

### DIFF
--- a/assets/config/lti_config_template.json
+++ b/assets/config/lti_config_template.json
@@ -1,0 +1,47 @@
+{
+  "title": "MyLA autoconfig-%(timestamp)s",
+  "scopes": [
+    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+    "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+    "https://canvas.instructure.com/lti/public_jwk/scope/update",
+    "https://canvas.instructure.com/lti/account_lookup/scope/show",
+    "https://canvas.instructure.com/lti/data_services/scope/create",
+    "https://canvas.instructure.com/lti/feature_flags/scope/show",
+    "https://canvas.instructure.com/lti/data_services/scope/list_event_types",
+    "https://canvas.instructure.com/lti/data_services/scope/destroy",
+    "https://canvas.instructure.com/lti/data_services/scope/list",
+    "https://canvas.instructure.com/lti/data_services/scope/update",
+    "https://canvas.instructure.com/lti/data_services/scope/show"
+  ],
+  "extensions": [
+    {
+      "domain": "%(host)s",
+      "platform": "canvas.instructure.com",
+      "settings": {
+        "platform": "canvas.instructure.com",
+        "placements": [
+          {
+            "default": "disabled",
+            "placement": "course_navigation",
+            "message_type": "LtiResourceLinkRequest",
+            "target_link_uri": "%(base_url)s%(launch_url_suffix)s"
+          }
+        ]
+      },
+      "privacy_level": "public"
+    }
+  ],
+  "public_jwk": {},
+  "description": "MyLA automatically generated configuration",
+  "custom_fields": {
+    "user_username": "$User.username",
+    "canvas_user_id": "$Canvas.user.id",
+    "canvas_course_id": "$Canvas.course.id"
+  },
+  "public_jwk_url": "%(base_url)s%(jwks_url_suffix)s",
+  "target_link_uri": "%(base_url)s%(launch_url_suffix)s",
+  "oidc_initiation_url": "%(base_url)s%(login_url_suffix)s"
+}

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -117,53 +117,6 @@
             }
         ]
     },
-    "LTI_CONFIG_TEMPLATE": {
-        "title": "MyLA autoconfig-{timestamp}",
-        "scopes": [
-            "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
-            "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
-            "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
-            "https://purl.imsglobal.org/spec/lti-ags/scope/score",
-            "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
-            "https://canvas.instructure.com/lti/public_jwk/scope/update",
-            "https://canvas.instructure.com/lti/account_lookup/scope/show",
-            "https://canvas.instructure.com/lti/data_services/scope/create",
-            "https://canvas.instructure.com/lti/feature_flags/scope/show",
-            "https://canvas.instructure.com/lti/data_services/scope/list_event_types",
-            "https://canvas.instructure.com/lti/data_services/scope/destroy",
-            "https://canvas.instructure.com/lti/data_services/scope/list",
-            "https://canvas.instructure.com/lti/data_services/scope/update",
-            "https://canvas.instructure.com/lti/data_services/scope/show"
-        ],
-        "extensions": [
-            {
-                "domain": "{host}",
-                "platform": "canvas.instructure.com",
-                "settings": {
-                    "platform": "canvas.instructure.com",
-                    "placements": [
-                        {
-                            "default": "disabled",
-                            "placement": "course_navigation",
-                            "message_type": "LtiResourceLinkRequest",
-                            "target_link_uri": "{base_url}{url_launch}"
-                        }
-                    ]
-                },
-                "privacy_level": "public"
-            }
-        ],
-        "public_jwk": {},
-        "description": "MyLA automatically generated configuration",
-        "custom_fields": {
-            "user_username": "$User.username",
-            "canvas_user_id": "$Canvas.user.id",
-            "canvas_course_id": "$Canvas.course.id"
-        },
-        "public_jwk_url": "{base_url}{url_get_jwks}",
-        "target_link_uri": "{base_url}{url_launch}",
-        "oidc_initiation_url": "{base_url}{url_login}"
-    },
     "/*Database caching using mysql cache for ltiv1p3":"*/",
     "DB_CACHE_CONFIGS": {
         "/*cache timeout":"*/",

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -117,6 +117,8 @@
             }
         ]
     },
+    "/*Full path in container to LTI config template.  If unset or null, defaults to location of 'config/lti_config_template.json' (usually '/code/assets/config/lti_config_template.json' in container)":"*/",
+    "LTI_CONFIG_TEMPLATE_PATH": null,
     "/*Database caching using mysql cache for ltiv1p3":"*/",
     "DB_CACHE_CONFIGS": {
         "/*cache timeout":"*/",

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -146,7 +146,7 @@
                             "default": "disabled",
                             "placement": "course_navigation",
                             "message_type": "LtiResourceLinkRequest",
-                            "target_link_uri": "{base_url}{url_login}"
+                            "target_link_uri": "{base_url}{url_launch}"
                         }
                     ]
                 },

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -117,6 +117,53 @@
             }
         ]
     },
+    "LTI_CONFIG_TEMPLATE": {
+        "title": "MyLA autoconfig-{timestamp}",
+        "scopes": [
+            "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+            "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
+            "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+            "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+            "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+            "https://canvas.instructure.com/lti/public_jwk/scope/update",
+            "https://canvas.instructure.com/lti/account_lookup/scope/show",
+            "https://canvas.instructure.com/lti/data_services/scope/create",
+            "https://canvas.instructure.com/lti/feature_flags/scope/show",
+            "https://canvas.instructure.com/lti/data_services/scope/list_event_types",
+            "https://canvas.instructure.com/lti/data_services/scope/destroy",
+            "https://canvas.instructure.com/lti/data_services/scope/list",
+            "https://canvas.instructure.com/lti/data_services/scope/update",
+            "https://canvas.instructure.com/lti/data_services/scope/show"
+        ],
+        "extensions": [
+            {
+                "domain": "{host}",
+                "platform": "canvas.instructure.com",
+                "settings": {
+                    "platform": "canvas.instructure.com",
+                    "placements": [
+                        {
+                            "default": "disabled",
+                            "placement": "course_navigation",
+                            "message_type": "LtiResourceLinkRequest",
+                            "target_link_uri": "{base_url}{url_login}"
+                        }
+                    ]
+                },
+                "privacy_level": "public"
+            }
+        ],
+        "public_jwk": {},
+        "description": "MyLA automatically generated configuration",
+        "custom_fields": {
+            "user_username": "$User.username",
+            "canvas_user_id": "$Canvas.user.id",
+            "canvas_course_id": "$Canvas.course.id"
+        },
+        "public_jwk_url": "{base_url}{url_get_jwks}",
+        "target_link_uri": "{base_url}{url_launch}",
+        "oidc_initiation_url": "{base_url}{url_login}"
+    },
     "/*Database caching using mysql cache for ltiv1p3":"*/",
     "DB_CACHE_CONFIGS": {
         "/*cache timeout":"*/",

--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -69,7 +69,7 @@ def check_if_success_getting_tool_config(tool_config):
         logger.info('Success in fetching LTI tool configuration')
         return True
     else:
-        logger.error(tool_config)
+        logger.error(f'Invalid LTI configuration: "{tool_config}"')
         return False
 
 
@@ -84,7 +84,8 @@ def generate_config_json(request: HttpRequest) -> \
         Union[HttpResponse, LTIError]:
     config = get_tool_conf()
     if not check_if_success_getting_tool_config(config):
-        return LTIError(config).response_json()
+        return LTIError(f'Invalid LTI configuration: "{config}"')\
+            .response_json()
 
     parameters = {
         'timestamp': datetime.now().isoformat(),

--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -1,7 +1,7 @@
 import logging, string, random
 import urllib.parse
 from datetime import datetime
-from typing import Mapping, MutableSequence, Union
+from typing import Mapping, MutableSequence, Union, Any
 
 import django.contrib.auth
 from django.contrib.staticfiles import finders
@@ -22,7 +22,6 @@ from pylti1p3.tool_config import ToolConfDict
 from dashboard.models import Course, CourseViewOption, User as MylaUser
 from dashboard.common.db_util import canvas_id_to_incremented_id
 
-
 logger = logging.getLogger(__name__)
 INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor'
 TA = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant'
@@ -30,53 +29,63 @@ COURSE_MEMBERSHIP = 'http://purl.imsglobal.org/vocab/lis/v2/membership'
 DUMMY_CACHE = 'DummyCache'
 
 
-class LTIError:
-    def __init__(self, msg):
-        self.msg = msg
+def lti_error(error_message: Any) -> JsonResponse:
+    """
+    Log an error message and return a JSON response with HTTP status 500.
 
-    def response_json(self):
-        error_message = {
-            'lti_error': f'{self.msg}'
-        }
-        return JsonResponse(error_message, status=500)
+    :param error_message: `Any` type is allowed so objects may be used
+    :return: JsonResponse, with status 500
+    """
+    logger.error(f'LTI error: {error_message}')
+    return JsonResponse({'lti_error': f'{error_message}'}, status=500)
 
 
 def get_tool_conf():
     lti_config = settings.LTI_CONFIG
+
     try:
-        tool_config = ToolConfDict(lti_config)
-    except Exception as e:
-        return e
-    # There should be one key per platform and the name relay on platforms generic domain not institution specific
+        config = ToolConfDict(lti_config)
+    except Exception as error:
+        return error
+
+    # There should be one key per platform
+    # and the name relay on platforms generic domain not institution specific
     platform_domain = list(lti_config.keys())[0]
-    client_id = lti_config[platform_domain][0]['client_id']
-    private_key_file_path = lti_config[platform_domain][0]['private_key_file']
-    public_key_file_path = lti_config[platform_domain][0]['public_key_file']
-    public_key = public_key_file_path if public_key_file_path else '/secret/public.key'
-    private_key = private_key_file_path if private_key_file_path else '/secret/private.key'
+    platform_config = lti_config[platform_domain][0]
+    client_id = platform_config['client_id']
+
     try:
-        private_key_content = open(private_key, 'r').read()
-        public_key_content = open(public_key, 'r').read()
-    except OSError as e:
-        return e
-    tool_config.set_public_key(platform_domain, public_key_content, client_id=client_id)
-    tool_config.set_private_key(platform_domain, private_key_content, client_id=client_id)
-    return tool_config
+        with open(platform_config.get(
+                'private_key_file', '/secrets/private.key'),
+                'r') as private_key_file:
+            config.set_private_key(
+                platform_domain, private_key_file.read(), client_id)
+
+        with open(platform_config.get(
+                'public_key_file', '/secrets/public.key'),
+                'r') as public_key_file:
+            config.set_public_key(
+                platform_domain, public_key_file.read(), client_id)
+
+    except OSError as error:
+        return error
+
+    return config
 
 
-def check_if_success_getting_tool_config(tool_config):
-    if isinstance(tool_config, ToolConfDict):
-        logger.info('Success in fetching LTI tool configuration')
+def is_config_valid(config: ToolConfDict):
+    if isinstance(config, ToolConfDict):
+        logger.info('LTI configuration valid.')
         return True
     else:
-        logger.error(f'Invalid LTI configuration: "{tool_config}"')
+        logger.error(f'Invalid LTI configuration: "{config}"')
         return False
 
 
 def get_jwks(_):
     config = get_tool_conf()
-    if not check_if_success_getting_tool_config(config):
-        return LTIError(config).response_json()
+    if not is_config_valid(config):
+        return lti_error(config)
     return JsonResponse(config.get_jwks())
 
 
@@ -189,12 +198,12 @@ def extract_launch_variables_for_tool_use(request, message_launch):
 @csrf_exempt
 def login(request):
     config = get_tool_conf()
-    if not check_if_success_getting_tool_config(config):
-        return LTIError(config).response_json()
+    if not is_config_valid(config):
+        return lti_error(config)
     target_link_uri = request.POST.get('target_link_uri', request.GET.get('target_link_uri'))
     if not target_link_uri:
         error_message = 'LTI Login failed due to missing "target_link_uri" param'
-        return LTIError(error_message).response_json()
+        return lti_error(error_message)
     CacheConfig = get_cache_config()
     oidc_login = DjangoOIDCLogin(request, config, launch_data_storage=CacheConfig.launch_data_storage)
     return oidc_login.enable_check_cookies().redirect(target_link_uri)
@@ -204,8 +213,8 @@ def login(request):
 @csrf_exempt
 def launch(request):
     config = get_tool_conf()
-    if not check_if_success_getting_tool_config(config):
-        return LTIError(config).response_json()
+    if not is_config_valid(config):
+        return lti_error(config)
     CacheConfig = get_cache_config()
     message_launch = DjangoMessageLaunch(request, config, launch_data_storage=CacheConfig.launch_data_storage)
     if not CacheConfig.is_dummy_cache:
@@ -218,8 +227,7 @@ def launch(request):
     try:
         course_id = extract_launch_variables_for_tool_use(request, message_launch)
     except Exception as e:
-        return LTIError(e).response_json()
+        return lti_error(e)
 
     url = reverse('courses', kwargs={'course_id': course_id})
     return redirect(url)
-

--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -1,7 +1,11 @@
 import logging, string, random
+import urllib.parse
+from datetime import datetime
+from typing import Mapping, MutableSequence, Union
+
 import django.contrib.auth
 
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpRequest
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.http import require_POST
@@ -73,6 +77,48 @@ def get_jwks(request):
     if not check_if_success_getting_tool_config(config):
         return LTIError(config).response_json()
     return JsonResponse(config.get_jwks())
+
+
+def recursive_format(args, **kwargs):
+    """
+    Recursively apply `string.format()` to all strings in a data structure.
+
+    This is intended to be used on a data structure that may contain
+    format strings just before it is passed to `json.dump()` or `dumps()`.
+
+    :param args: data structure; mostly dictionaries and lists
+    :param kwargs: values to be used in `string.format()`
+    :return: a new data structure with formatted strings
+    """
+    if isinstance(args, Mapping):
+        return {key: recursive_format(value, **kwargs)
+                for (key, value) in args.items()}
+    elif isinstance(args, MutableSequence):
+        return [recursive_format(value, **kwargs)
+                for value in args]
+    else:
+        return args.format(**kwargs)
+
+
+def generate_config_json(request: HttpRequest) -> Union[
+    JsonResponse, LTIError]:
+    config = get_tool_conf()
+    if not check_if_success_getting_tool_config(config):
+        return LTIError(config).response_json()
+
+    params = {
+        'timestamp': datetime.now().isoformat(),
+        'host': request.get_host(),
+        'base_url': urllib.parse.urlunsplit(
+            [request.scheme, request.get_host()] + 3 * ['']),
+        'url_login': reverse('login'),
+        'url_launch': reverse('launch'),
+        'url_get_jwks': reverse('get_jwks'),
+    }
+
+    return JsonResponse(
+        recursive_format(settings.LTI_CONFIG_TEMPLATE, **params)
+    )
 
 
 def get_cache_config():

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -413,6 +413,7 @@ if STUDENT_DASHBOARD_SAML:
 
 if STUDENT_DASHBOARD_LTI:
     LTI_CONFIG = ENV.get('LTI_CONFIG', {})
+    LTI_CONFIG_TEMPLATE_PATH = ENV.get('LTI_CONFIG_TEMPLATE_PATH')
 
 # controls whether Unizin specific features/data is available from the Canvas Data source
 DATA_WAREHOUSE_IS_UNIZIN = ENV.get("DATA_WAREHOUSE_IS_UNIZIN", True)

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -413,7 +413,6 @@ if STUDENT_DASHBOARD_SAML:
 
 if STUDENT_DASHBOARD_LTI:
     LTI_CONFIG = ENV.get('LTI_CONFIG', {})
-    LTI_CONFIG_TEMPLATE = ENV.get('LTI_CONFIG_TEMPLATE', {})
 
 # controls whether Unizin specific features/data is available from the Canvas Data source
 DATA_WAREHOUSE_IS_UNIZIN = ENV.get("DATA_WAREHOUSE_IS_UNIZIN", True)

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -413,6 +413,7 @@ if STUDENT_DASHBOARD_SAML:
 
 if STUDENT_DASHBOARD_LTI:
     LTI_CONFIG = ENV.get('LTI_CONFIG', {})
+    LTI_CONFIG_TEMPLATE = ENV.get('LTI_CONFIG_TEMPLATE', {})
 
 # controls whether Unizin specific features/data is available from the Canvas Data source
 DATA_WAREHOUSE_IS_UNIZIN = ENV.get("DATA_WAREHOUSE_IS_UNIZIN", True)

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -95,7 +95,8 @@ if settings.STUDENT_DASHBOARD_LTI:
         path('lti/login/', lti_new.login, name='login'),
         path('lti/launch/', lti_new.launch, name='launch'),
         path('lti/jwks/', lti_new.get_jwks, name='get_jwks'),
-        path('lti/config/', lti_new.generate_config_json, name=lti_new.generate_config_json.__name__),
+        path('lti/config/', lti_new.generate_config_json,
+             name=lti_new.generate_config_json.__name__),
     )
 
 if settings.ENABLE_BACKEND_LOGIN:

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -92,9 +92,10 @@ if apps.is_installed('djangosaml2'):
 if settings.STUDENT_DASHBOARD_LTI:
     from . import lti_new
     urlpatterns += (
-        path('lti/login/', lti_new.login, name="login"),
-        path('lti/launch/', lti_new.launch, name="launch"),
-        path('lti/jwks/', lti_new.get_jwks, name="get_jwks"),
+        path('lti/login/', lti_new.login, name='login'),
+        path('lti/launch/', lti_new.launch, name='launch'),
+        path('lti/jwks/', lti_new.get_jwks, name='get_jwks'),
+        path('lti/config/', lti_new.generate_config_json, name=lti_new.generate_config_json.__name__),
     )
 
 if settings.ENABLE_BACKEND_LOGIN:


### PR DESCRIPTION
Resolves #1054.

I'm working on wiki docs for this new feature.

## Changes based on code review
* [x] Move the LTI config template out of `config/env_sample.json` and into a new file, `assets/config/lti_config_template.json`.  See: https://github.com/tl-its-umich-edu/my-learning-analytics/pull/1105#discussion_r502669168
* [x] Change `"target_link_uri": "{base_url}{url_login}"` in template from `url_login` to `url_launch`.  See: https://github.com/tl-its-umich-edu/my-learning-analytics/pull/1105#discussion_r505511939


## Testing
More testing details in the issue, #1054. 
1. Go to Canvas' LTI Developer Key creation page:
    * https://umich.instructure.com/accounts/1/developer_keys#lti_key_modal_opened
1. In the "Method" menu, select the "Enter URL" item.
1. Copy the following URL and paste it into the "JSON URL" field:
    * https://nnnnnnnnnnnn.ngrok.io/lti/config/
    * Replace "nnnnnnnnnnnn" with the ID number of your ngrok server.
1. Copy the following URL and paste it into the "Redirect URIs" field:
    * https://nnnnnnnnnnnn.ngrok.io/lti/launch/
    * Replace "nnnnnnnnnnnn" with the ID number of your ngrok server.
1. (Optional, recommended) Enter meaningful values into the "Key Name", "Owner Email", and "Notes" fields.
1. Click the "Save" button.
