### PR TITLE
#1125 fixes missing current and Max grade line for AssignV2

### DIFF
--- a/assets/src/util/assignment.js
+++ b/assets/src/util/assignment.js
@@ -108,10 +108,10 @@ const calculateWeight = (pointsPossible, assignmentGroupId, assignmentGroups) =>
 const calculateMaxGrade = (assignments, assignmentGroups, assignmentWeightConsideration) => {
   const [totalUserPoints, totalPossiblePoints] = assignments
     .reduce((acc, a) => {
-      const assignmentGrade = a.graded
+      const assignmentGrade = a.graded && a.pointsPossible !== 0
         ? a.currentUserSubmission.score / a.pointsPossible
         // if user sets assignment goal, use the set goal as part of grade calc.
-        : a.goalGradeSetByUser
+        : a.goalGradeSetByUser && a.pointsPossible !== 0
           ? a.goalGrade / a.pointsPossible
           // give a perfect score if assignment is not graded to calculate the max grade possible.
           : 1


### PR DESCRIPTION
#1125 

The missing of the current and Max grades was happening with certain assignment doesn't had points meaning points = 0 or null (no point at all). I can say sometime instructor creates these assignments as a reading assignments or for attendance purposes. The progress bar is not considering those assignments in those cases 