### PR TITLE
Fixes #1108 - Problem starting up when not setting GUNICORN_RELOAD

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,8 +27,7 @@
             ],
             "port": 3001,
             "host": "localhost",
-            "justMyCode": false,
-            "subProcess": true
+            "justMyCode": false
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,8 @@
             ],
             "port": 3001,
             "host": "localhost",
-            "justMyCode": false
+            "justMyCode": false,
+            "subProcess": true
         }
     ]
 }

--- a/start.sh
+++ b/start.sh
@@ -24,7 +24,7 @@ fi
 if [ "${GUNICORN_RELOAD}" ]; then
     GUNICORN_RELOAD="--reload"
 else
-    GUNICORN_RELOAD=""
+    GUNICORN_RELOAD=
 fi
 
 DOMAIN_JQ='.ALLOWED_HOSTS | . - ["127.0.0.1", "localhost", ".ngrok.io"] | if . | length == 0 then "localhost" else .[0] end'
@@ -81,11 +81,12 @@ if [ "${IS_CRON_POD:-"false",,}" == "false" ]; then
         echo "Starting Gunicorn for PTVSD debugging"
         # Workers need to be set to 1 for PTVSD
         GUNICORN_WORKERS=1
+        GUNICORN_RELOAD="--reload"
     fi
     exec gunicorn dashboard.wsgi:application \
         --bind 0.0.0.0:${GUNICORN_PORT} \
         --workers="${GUNICORN_WORKERS}" \
-        "${GUNICORN_RELOAD}"
+        ${GUNICORN_RELOAD}
  
 else
     if [ -z "${CRONTAB_SCHEDULE}" ]; then

--- a/start.sh
+++ b/start.sh
@@ -82,10 +82,12 @@ if [ "${IS_CRON_POD:-"false",,}" == "false" ]; then
         # Workers need to be set to 1 for PTVSD
         GUNICORN_WORKERS=1
         GUNICORN_RELOAD="--reload"
+        GUNICORN_TIMEOUT=0
     fi
     exec gunicorn dashboard.wsgi:application \
         --bind 0.0.0.0:${GUNICORN_PORT} \
         --workers="${GUNICORN_WORKERS}" \
+        --timeout="${GUNICORN_TIMEOUT}" \
         ${GUNICORN_RELOAD}
  
 else


### PR DESCRIPTION
Really just removed the quotes from gunicorn. With the exec it was causing it to expand to single quotes when not set and this is always either set to a specific variable or unset so safe.

Also setting it to reload now if debugging is on.