### PR TITLE
Introduce warning color to theme palette, use in StyledTextField (#878)

### DIFF
--- a/assets/src/components/StyledTextField.js
+++ b/assets/src/components/StyledTextField.js
@@ -1,23 +1,21 @@
 import TextField from '@material-ui/core/TextField'
 import { withStyles } from '@material-ui/core/styles'
 
-const orange = '#ffae42'
-
-const StyledTextField = withStyles({
+const StyledTextField = withStyles(theme => ({
   root: {
     '& .MuiFormLabel-root.Mui-error': {
-      color: orange
+      color: theme.palette.warning.dark
     },
     '& .MuiInput-underline.Mui-error:after': {
-      borderBottomColor: orange
+      borderBottomColor: theme.palette.warning.main
     },
     '& .MuiInputBase-input': {
       color: 'green'
     },
     '& .MuiOutlinedInput-root.Mui-error .MuiOutlinedInput-notchedOutline': {
-      borderColor: orange
+      borderColor: theme.palette.warning.main
     }
   }
-})(TextField)
+}))(TextField)
 
 export default StyledTextField

--- a/assets/src/components/StyledTextField.js
+++ b/assets/src/components/StyledTextField.js
@@ -1,16 +1,21 @@
 import TextField from '@material-ui/core/TextField'
 import { withStyles } from '@material-ui/core/styles'
 
+const orange = '#ffae42'
+
 const StyledTextField = withStyles({
   root: {
     '& .MuiFormLabel-root.Mui-error': {
-      color: '#ffae42'
+      color: orange
     },
     '& .MuiInput-underline.Mui-error:after': {
-      borderBottomColor: '#ffae42'
+      borderBottomColor: orange
     },
     '& .MuiInputBase-input': {
       color: 'green'
+    },
+    '& .MuiOutlinedInput-root.Mui-error .MuiOutlinedInput-notchedOutline': {
+      borderColor: orange
     }
   }
 })(TextField)

--- a/assets/src/defaultPalette.js
+++ b/assets/src/defaultPalette.js
@@ -26,8 +26,10 @@ const defaultPalette = {
   info: {
     main: '#FFB74D'
   },
+  /*  The 'warning' color is used with text or interface elements to alert the user something may be wrong or
+      need their attention. */
   warning: {
-    main: '#FF6E00'
+    main: '#D84315'
   }
 }
 

--- a/assets/src/defaultPalette.js
+++ b/assets/src/defaultPalette.js
@@ -22,11 +22,12 @@ const defaultPalette = {
   link: {
     main: '#0000EE'
   },
-  /*  The 'info' color is used to confirm a submitted or stored by system state .
-    For now, this should be used directly through theme.palette.info.main instead of the color prop
-    (i.e. color='info'), which isn't fully supported. */
+  /*  The 'info' color is used to confirm a submitted or stored by system state. */
   info: {
-    main: '#ffb74d'
+    main: '#FFB74D'
+  },
+  warning: {
+    main: '#FF6E00'
   }
 }
 

--- a/assets/src/defaultPalette.js
+++ b/assets/src/defaultPalette.js
@@ -27,7 +27,7 @@ const defaultPalette = {
     main: '#FFB74D'
   },
   /*  The 'warning' color is used with text or interface elements to alert the user something may be wrong or
-      need their attention. */
+      needs their attention. */
   warning: {
     main: '#D84315'
   }


### PR DESCRIPTION
This PR adds a `warning` color to the `defaultPalette` for use in the Assignment Redesign (specifically for the `StyledTextField`). Because `warning` is a standard color in Material UI (see [Palette](https://material-ui.com/customization/palette/)), it can be used with the `color` prop or `withStyles(theme => ({})...`. I conferred with @jennlove-um on the hex value choices; the `dark` variant is used for the text to ensure it meets W3C contrast requirements but fits with the `main` variant used in the outline and bottom line. The PR aims to resolve issue #878.

Note: the `info` color in the palette is also a shade of orange. We will be separately assessing whether it makes sense to modify that value for consistency/clarity.