### PR TITLE
Make axis lines, ticks, and text black (where appropriate) (#802)

### DIFF
--- a/assets/src/__tests__/components/d3/__snapshots__/createHistogram.test.js.snap
+++ b/assets/src/__tests__/components/d3/__snapshots__/createHistogram.test.js.snap
@@ -809,6 +809,7 @@ exports[`createHistogram should build a histogram bar chart binning last five gr
         />
       </g>
       <g
+        class="black-axis-line black-axis-text"
         fill="none"
         font-family="sans-serif"
         font-size="10"
@@ -924,7 +925,6 @@ exports[`createHistogram should build a histogram bar chart binning last five gr
         </g>
         <text
           dy="-4"
-          fill="rgba(0, 0, 0, 0.87)"
           font-size="0.875rem"
           font-weight="400"
           line-height="1.46429em"
@@ -933,7 +933,7 @@ exports[`createHistogram should build a histogram bar chart binning last five gr
         />
       </g>
       <g
-        class="axis"
+        class="gray-axis-line black-axis-text"
         fill="none"
         font-family="sans-serif"
         font-size="10"

--- a/assets/src/components/d3/createHistogram.js
+++ b/assets/src/components/d3/createHistogram.js
@@ -86,6 +86,7 @@ function createHistogram ({ data, width, height, domElement, xAxisLabel, yAxisLa
 
   const xAxis = g => g
     .attr('transform', `translate(0, ${aHeight - margin.bottom})`)
+    .attr('class', 'black-axis-line black-axis-text')
     .call(d3
       .axisBottom(x)
       .tickSizeOuter(0)
@@ -95,7 +96,6 @@ function createHistogram ({ data, width, height, domElement, xAxisLabel, yAxisLa
     .call(g => g.append('text')
       .attr('x', aWidth / 2)
       .attr('y', 40)
-      .attr('fill', 'rgba(0, 0, 0, 0.87)')
       .attr('font-size', '0.875rem')
       .attr('font-weight', '400')
       .attr('line-height', '1.46429em')
@@ -105,7 +105,7 @@ function createHistogram ({ data, width, height, domElement, xAxisLabel, yAxisLa
 
   const yAxis = g => g
     .attr('transform', `translate(${margin.left},0)`)
-    .attr('class', 'axis')
+    .attr('class', 'black-axis-text axis')
     .call(d3.axisLeft(y).tickSizeInner(-aWidth).ticks(5))
     .call(g => g.select('.domain').remove())
     .call(g => g.select('.tick:last-of-type text').clone()

--- a/assets/src/components/d3/createHistogram.js
+++ b/assets/src/components/d3/createHistogram.js
@@ -105,7 +105,7 @@ function createHistogram ({ data, width, height, domElement, xAxisLabel, yAxisLa
 
   const yAxis = g => g
     .attr('transform', `translate(${margin.left},0)`)
-    .attr('class', 'black-axis-text axis')
+    .attr('class', 'gray-axis-line black-axis-text')
     .call(d3.axisLeft(y).tickSizeInner(-aWidth).ticks(5))
     .call(g => g.select('.domain').remove())
     .call(g => g.select('.tick:last-of-type text').clone()

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -403,7 +403,7 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
   // Append axis to main chart
   const xAxis = d3.select('.mainGroupWrapper')
     .append('g')
-    .attr('class', 'axis axis--x')
+    .attr('class', 'black-axis-line black-axis-text axis--x')
     .attr('transform', `translate(0,${mainHeight})`)
     .call(mainXAxis.tickFormat(d => d + '%'))
 
@@ -416,7 +416,7 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
     .style('font-size', '14px')
 
   mainGroup.append('g')
-    .attr('class', 'axis axis--y')
+    .attr('class', 'black-axis-line axis--y')
     .attr('transform', 'translate(0,0)')
     .call(mainYAxis)
 

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -403,7 +403,7 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
   // Append axis to main chart
   const xAxis = d3.select('.mainGroupWrapper')
     .append('g')
-    .attr('class', 'black-axis-line black-axis-text axis--x')
+    .attr('class', 'axis--x black-axis-line black-axis-text')
     .attr('transform', `translate(0,${mainHeight})`)
     .call(mainXAxis.tickFormat(d => d + '%'))
 
@@ -416,7 +416,7 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
     .style('font-size', '14px')
 
   mainGroup.append('g')
-    .attr('class', 'black-axis-line axis--y')
+    .attr('class', 'axis--y black-axis-line')
     .attr('transform', 'translate(0,0)')
     .call(mainYAxis)
 

--- a/assets/src/index.css
+++ b/assets/src/index.css
@@ -16,11 +16,11 @@ code {
 }
 
 .black-axis-line line {
-  stroke: #000000;
+  stroke: #000;
 }
 
 .black-axis-text text {
-  fill: #000000;
+  fill: #000;
 }
 
 .spinner {

--- a/assets/src/index.css
+++ b/assets/src/index.css
@@ -19,10 +19,6 @@ code {
   stroke: black;
 }
 
-.black-axis-line path {
-  stroke: black;
-}
-
 .black-axis-text text {
   fill: black;
 }

--- a/assets/src/index.css
+++ b/assets/src/index.css
@@ -15,6 +15,18 @@ code {
   stroke: rgba(0,0,0,0.18)
 }
 
+.black-axis-line line {
+  stroke: black;
+}
+
+.black-axis-line path {
+  stroke: black;
+}
+
+.black-axis-text text {
+  fill: black;
+}
+
 .spinner {
   width: 40px;
   height: 40px;

--- a/assets/src/index.css
+++ b/assets/src/index.css
@@ -11,16 +11,16 @@ code {
     monospace;
 }
 
-.axis line {
+.gray-axis-line line {
   stroke: rgba(0,0,0,0.18)
 }
 
 .black-axis-line line {
-  stroke: black;
+  stroke: #000000;
 }
 
 .black-axis-text text {
-  fill: black;
+  fill: #000000;
 }
 
 .spinner {


### PR DESCRIPTION
This PR modifies class names and SVG `line` and `text` classes to improve contrast on axes in the Grade Distribution and Resources Accessed views. All ticks, text, and lines should be black, with the exception of the gray horizontal lines in the Grade Distribution, which @jennlove-um and I agreed may disrupt the visualization if they were black. The PR aims to resolve issue #802.