### PR TITLE
#1156 removing the warning message

### DIFF
--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -472,9 +472,8 @@ function AssignmentTable (props) {
             </TableBody>
           </MTable>
         </TableContainer>
-        {assignments.length > 0 && filteredAssignments.length === 0 &&
-          <AlertBanner>No assignments match your filter selections.</AlertBanner>}
       </RootRef>
+      {assignments.length > 0 && filteredAssignments.length === 0 && <AlertBanner>No assignments match your filter selections.</AlertBanner>}
     </div>
   )
 }


### PR DESCRIPTION
Fixes #1156.

With recent [merges](https://github.com/tl-its-umich-edu/my-learning-analytics/commit/58242d02003ec79c7ed7b85cd115e740e3e1c6a5) I see this issue is happening. I did not create another issue but tagged as part of 1156

```
react_devtools_backend.js:2430 Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `RootRef`, expected a single ReactElement.
    in RootRef (created by AssignmentTable)
    in AssignmentTable (created by WithStyles(AssignmentTable))
    in WithStyles(AssignmentTable) (created by AssignmentPlanningV2)
    in div (created by AssignmentPlanningV2)
    in div (created by AssignmentPlanningV2)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by AssignmentPlanningV2)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by AssignmentPlanningV2)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by AssignmentPlanningV2)
    in div (created by AssignmentPlanningV2)
    in AssignmentPlanningV2 (created by WithStyles(AssignmentPlanningV2))
    in WithStyles(AssignmentPlanningV2) (created by Context.Consumer)
    in Route (created by Course)
    in Course (created by WithStyles(Course))
    in WithStyles(Course) (created by App)
    in App (created by Context.Consumer)
    in withRouter(App)
    in ThemeProvider
    in ApolloProvider
    in Router (created by BrowserRouter)
    in BrowserRouter
````