### PR TITLE
When a new course is added with a start date in the future, nothing i…

### DIFF
--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -249,7 +249,7 @@ class DashboardCronJob(CronJobBase):
         # BQ Total Bytes Billed to report to status
         total_bytes_billed = 0
 
-        data_last_updated = Course.objects.filter(id__in=self.valid_locked_course_ids).get_data_last_updated()
+        data_last_updated = Course.objects.filter(id__in=self.valid_locked_course_ids).get_data_earliest_date()
 
         logger.info(f"Deleting all records in resource_access after {data_last_updated}")
 

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -187,7 +187,7 @@ class CourseQuerySet(models.QuerySet):
             earliest_start_date_of_new_courses = new_courses.earliest_start_datetime()
 
         # Return the lower value of existing_earliest and new_earliest, otherwise return None
-        return min((val for val in [earliest_data_last_updated, earliest_start_date_of_new_courses] if val is not None), default=None)
+        return min(filter(None, (earliest_data_last_updated, earliest_start_date_of_new_courses)), default=None)
 
 
 class Course(models.Model):

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -182,12 +182,12 @@ class CourseQuerySet(models.QuerySet):
 
         earliest_data_last_updated = existing_courses.earliest("data_last_updated").data_last_updated
         # If there are new courses (courses with no last run) return the earliest time of all
-        earliest_start_date_of_new_courses = None
+        earliest_start_datetime = None
         if len(new_courses) > 0:
-            earliest_start_date_of_new_courses = new_courses.earliest_start_datetime()
+            earliest_start_datetime = new_courses.earliest_start_datetime()
 
         # Return the lower value of existing_earliest and new_earliest, otherwise return None
-        return min(filter(None, (earliest_data_last_updated, earliest_start_date_of_new_courses)), default=None)
+        return min(filter(None, (earliest_data_last_updated, earliest_start_datetime)), default=None)
 
 
 class Course(models.Model):

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -172,17 +172,22 @@ class CourseQuerySet(models.QuerySet):
         """ Returns the datetime of the last cron run of all courses
             This checks for any courses where the data_last_updated value is null.
 
+            If there are new courses it will return the lower value of the last run date or the earliest start date.
+
         :return: datetime. Either the earliest or None
-        :rtype: None
+        :rtype: None, datetime
         """
         new_courses = self.filter(data_last_updated__isnull=True)
+        existing_courses = self.filter(data_last_updated__isnull=False)
 
+        existing_earliest = existing_courses.earliest("data_last_updated").data_last_updated
         # If there are new courses (courses with no last run) return the earliest time of all
+        new_earliest = None
         if len(new_courses) > 0:
-            return new_courses.earliest_start_datetime()
-        # Otherwise return the latest cron run
-        else:
-            return self.all().latest("data_last_updated").data_last_updated
+            new_earliest = new_courses.earliest_start_datetime()
+
+        # Return the lower value of existing_earliest and new_earliest, otherwise return None
+        return min((val for val in [existing_earliest, new_earliest] if val is not None), default=None)
 
 
 class Course(models.Model):

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -168,7 +168,7 @@ class CourseQuerySet(models.QuerySet):
             logger.info(f"No courses in CourseQuerySet; returning None as the earliest_start_datetime")
         return earliest_start
 
-    def get_data_last_updated(self) -> Optional[datetime]:
+    def get_data_earliest_date(self) -> Optional[datetime]:
         """ Returns the datetime of the last cron run of all courses
             This checks for any courses where the data_last_updated value is null.
 
@@ -180,14 +180,14 @@ class CourseQuerySet(models.QuerySet):
         new_courses = self.filter(data_last_updated__isnull=True)
         existing_courses = self.filter(data_last_updated__isnull=False)
 
-        existing_earliest = existing_courses.earliest("data_last_updated").data_last_updated
+        earliest_data_last_updated = existing_courses.earliest("data_last_updated").data_last_updated
         # If there are new courses (courses with no last run) return the earliest time of all
-        new_earliest = None
+        earliest_start_date_of_new_courses = None
         if len(new_courses) > 0:
-            new_earliest = new_courses.earliest_start_datetime()
+            earliest_start_date_of_new_courses = new_courses.earliest_start_datetime()
 
         # Return the lower value of existing_earliest and new_earliest, otherwise return None
-        return min((val for val in [existing_earliest, new_earliest] if val is not None), default=None)
+        return min((val for val in [earliest_data_last_updated, earliest_start_date_of_new_courses] if val is not None), default=None)
 
 
 class Course(models.Model):


### PR DESCRIPTION
…s run and a day is missed.

* Changes the logic to return the minimum of either the earlier last run
  or the start time.
* Changes latest to earliest in the Django. Previously this didn't
  matter since all of these times were the same.

Fixes #1138