### PR TITLE
Make Typography component in help docs link appear as p tag instead of h4 (#807)

### DIFF
--- a/assets/src/components/SelectCard.js
+++ b/assets/src/components/SelectCard.js
@@ -154,7 +154,7 @@ const SelectCard = props => {
   function getHelpLink (cardData) {
     if (cardData.helpUrl) {
       return (
-        <Typography gutterBottom variant='h5' component='h4' className={classes.title + ' ' + classes.titleIcon}>
+        <Typography gutterBottom variant='h5' component='p' className={classes.title + ' ' + classes.titleIcon}>
           <Tooltip title={'About ' + cardData.title}>
             <MUILink className={classes.infoLink} href={cardData.helpUrl} target='_blank' rel='noopener noreferrer'>
               <InfoIcon fontSize='large' />


### PR DESCRIPTION
This PR modifies the underlying element of the `Typography` component of the help doc links so it uses a `p` element instead of `h4`. The `h4` may pose accessibility issues because of skipped header levels, and it doesn't really accurately capture the purpose of the link. The styling is maintained because `variant='h5'` remains on the component. The PR aims to finish resolving issue #807.

See Typography API, `component`: https://material-ui.com/api/typography/