### PR TITLE
Show PopUpMessage with assignment-specific progress bars when navigated to by keyboard (#800)

### DIFF
--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -26,6 +26,7 @@ import PopupMessage from './PopupMessage'
 import ConditionalWrapper from './ConditionalWrapper'
 import StyledTextField from './StyledTextField'
 import AlertBanner from '../components/AlertBanner'
+import usePopoverEl from '../hooks/usePopoverEl'
 import { calculateWeekOffset } from '../util/date'
 import { roundToXDecimals, getDecimalPlaceOfFloat } from '../util/math'
 import { assignmentStatus } from '../util/assignment'
@@ -122,7 +123,7 @@ function AssignmentTable (props) {
   */
   const [filteredAssignments, setFilteredAssignments] = useState(assignments)
 
-  const [popoverEl, setPopoverEl] = useState({ popoverId: null, anchorEl: null })
+  const [popoverEl, setPopover, clearPopover] = usePopoverEl()
 
   const [assignmentGroupNames, setAssignmentGroupNames] = useState([])
 
@@ -438,8 +439,8 @@ function AssignmentTable (props) {
                             </div>
                           }
                           <div
-                            onMouseEnter={event => setPopoverEl({ popoverId: key, anchorEl: event.currentTarget })}
-                            onMouseLeave={() => setPopoverEl({ popoverId: null, anchorEl: null })}
+                            onMouseEnter={event => setPopover(key, event.currentTarget)}
+                            onMouseLeave={clearPopover}
                           >
                             <ProgressBarV2
                               score={a.currentUserSubmission ? a.currentUserSubmission.score : 0}
@@ -459,13 +460,15 @@ function AssignmentTable (props) {
                               Your grade: ${(a.grade ? a.grade : 'Not graded')}.  
                               Class average: ${a.averageGrade}.  
                               Rules: ${(a.rules ? a.rules : 'There are no rules for this assignment')}.  `}
+                              onBarFocus={(el) => setPopover(key, el)}
+                              onBarBlur={clearPopover}
                             />
                             <Popover
                               className={classes.popover}
                               classes={{ paper: classes.paper }}
                               anchorEl={popoverEl.anchorEl}
                               open={popoverEl.popoverId === key}
-                              onClose={() => setPopoverEl({ popoverId: null, anchorEl: null })}
+                              onClose={clearPopover}
                               anchorOrigin={{
                                 vertical: 'top',
                                 horizontal: 'left'
@@ -475,6 +478,8 @@ function AssignmentTable (props) {
                                 horizontal: 'left'
                               }}
                               disableRestoreFocus
+                              disableAutoFocus
+                              disableEnforceFocus
                             >
                               <PopupMessage a={a} assignmentGroups={assignmentGroups} />
                             </Popover>

--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -123,7 +123,7 @@ function AssignmentTable (props) {
   */
   const [filteredAssignments, setFilteredAssignments] = useState(assignments)
 
-  const [popoverEl, setPopover, clearPopover] = usePopoverEl()
+  const [popoverEl, setPopoverEl, clearPopoverEl] = usePopoverEl()
 
   const [assignmentGroupNames, setAssignmentGroupNames] = useState([])
 
@@ -439,8 +439,8 @@ function AssignmentTable (props) {
                             </div>
                           }
                           <div
-                            onMouseEnter={event => setPopover(key, event.currentTarget)}
-                            onMouseLeave={clearPopover}
+                            onMouseEnter={event => setPopoverEl(key, event.currentTarget)}
+                            onMouseLeave={clearPopoverEl}
                           >
                             <ProgressBarV2
                               score={a.currentUserSubmission ? a.currentUserSubmission.score : 0}
@@ -460,15 +460,15 @@ function AssignmentTable (props) {
                               Your grade: ${(a.grade ? a.grade : 'Not graded')}.  
                               Class average: ${a.averageGrade}.  
                               Rules: ${(a.rules ? a.rules : 'There are no rules for this assignment')}.  `}
-                              onBarFocus={(el) => setPopover(key, el)}
-                              onBarBlur={clearPopover}
+                              onBarFocus={el => setPopoverEl(key, el)}
+                              onBarBlur={clearPopoverEl}
                             />
                             <Popover
                               className={classes.popover}
                               classes={{ paper: classes.paper }}
                               anchorEl={popoverEl.anchorEl}
                               open={popoverEl.popoverId === key}
-                              onClose={clearPopover}
+                              onClose={clearPopoverEl}
                               anchorOrigin={{
                                 vertical: 'top',
                                 horizontal: 'left'

--- a/assets/src/components/ProgressBarV2.js
+++ b/assets/src/components/ProgressBarV2.js
@@ -28,7 +28,9 @@ function ProgressBarV2 (props) {
     height = 10,
     margin,
     lines = [],
-    description
+    description,
+    onBarFocus,
+    onBarBlur
   } = props
 
   const scoreRatio = score
@@ -60,6 +62,8 @@ function ProgressBarV2 (props) {
             position: 'relative',
             margin: margin
           }}
+          onFocus={(event) => { if (onBarFocus) onBarFocus(event.currentTarget) }}
+          onBlur={(event) => { if (onBarBlur) onBarBlur() }}
         >
           {
             lines.length > 0

--- a/assets/src/hooks/usePopoverEl.js
+++ b/assets/src/hooks/usePopoverEl.js
@@ -1,15 +1,14 @@
 import { useState } from 'react'
 
 function usePopoverEl () {
-  const emptyPopover = { popoverId: null, anchorEl: null }
-  const [popoverEl, setPopoverEl] = useState(emptyPopover)
+  const emptyPopoverEl = { popoverId: null, anchorEl: null }
+  const [popoverEl, setPopoverEl] = useState(emptyPopoverEl)
 
-  const setPopover = (key, el) => {
-    setPopoverEl({ popoverId: key, anchorEl: el })
-  }
-  const clearPopover = () => setPopoverEl(emptyPopover)
+  const setNewPopoverEl = (key, el) => setPopoverEl({ popoverId: key, anchorEl: el })
 
-  return [popoverEl, setPopover, clearPopover]
+  const clearPopoverEl = () => setPopoverEl(emptyPopoverEl)
+
+  return [popoverEl, setNewPopoverEl, clearPopoverEl]
 }
 
 export default usePopoverEl

--- a/assets/src/hooks/usePopoverEl.js
+++ b/assets/src/hooks/usePopoverEl.js
@@ -1,0 +1,15 @@
+import { useState } from 'react'
+
+function usePopoverEl () {
+  const emptyPopover = { popoverId: null, anchorEl: null }
+  const [popoverEl, setPopoverEl] = useState(emptyPopover)
+
+  const setPopover = (key, el) => {
+    setPopoverEl({ popoverId: key, anchorEl: el })
+  }
+  const clearPopover = () => setPopoverEl(emptyPopover)
+
+  return [popoverEl, setPopover, clearPopover]
+}
+
+export default usePopoverEl


### PR DESCRIPTION
This PR presents a functional, if imperfect, solution that allows users to view the `PopUpMessage` content when an assignment-specific progress bar is navigated to using a keyboard. It is "imperfect" in the sense that there is a visual bug where if the user scrolls or uses the up or down arrow key when a bar is focused and the pop-up is visible, the pop-up will keep its position in the entire window and move away from the bar. @jennlove-um thinks this partial solution may be acceptable for now, and we can continue to refine it going forward. These changes include a `usePopoverEl` custom hook to reduce some duplication between the `onFocus` and `onBlur` handlers and the mouse-over handlers. The PR aims to resolve issue #800. 