### PR TITLE
Update webpack and webpack-cli to latest 4.x versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
     "style-loader": "~0.23.1",
     "typeface-roboto": "0.0.54",
     "url-loader": "1.1.2",
-    "webpack": "~4.29.6",
+    "webpack": "4.44.x",
     "webpack-bundle-tracker": "^0.4.3",
-    "webpack-cli": "4.2.0"
+    "webpack-cli": "4.3.x"
   }
 }


### PR DESCRIPTION
This also fixes #1184 

Built with 
`docker-compose build --no-cache`