### PR TITLE
Handle lack of Git environment variables better in util function and template (#1236)

### DIFF
--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -1,5 +1,5 @@
 import logging, os, re
-from typing import Optional, Union, TypedDict
+from typing import Optional, TypedDict, Union
 
 from django.conf import settings
 from constance import config

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -21,34 +21,34 @@ def format_github_url_using_https(github_url: str):
 
 class GitInfo(TypedDict):
     repo: str
+    branch: str
     commit: str
     commit_abbrev: str
-    branch: str
 
 
 def get_git_version_info() -> Optional[GitInfo]:
     logger.debug(get_git_version_info.__name__)
 
-    commit = os.getenv("GIT_COMMIT", None)
-    branch = os.getenv("GIT_BRANCH", None)
     repo = os.getenv("GIT_REPO", None)
+    branch = os.getenv("GIT_BRANCH", None)
+    commit = os.getenv("GIT_COMMIT", None)
 
     if not repo or not branch or not commit:
         return None
+
+    # Only include the branch name and not remote info
+    branch = branch.split('/')[-1]
 
     commit_abbrev = (
         commit[:settings.SHA_ABBREV_LENGTH]
         if len(commit) > settings.SHA_ABBREV_LENGTH else commit
     )
 
-    # Only include the branch name and not remote info
-    branch = branch.split('/')[-1]
-
     return {
         "repo": format_github_url_using_https(repo),
+        "branch": branch,
         "commit": commit,
-        "commit_abbrev": commit_abbrev,
-        "branch": branch
+        "commit_abbrev": commit_abbrev
     }
 
 

--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -1,5 +1,5 @@
 import logging, os, re
-from typing import Union
+from typing import Optional, Union, TypedDict
 
 from django.conf import settings
 from constance import config
@@ -10,7 +10,7 @@ from dashboard.models import Course, ResourceAccess
 
 logger = logging.getLogger(__name__)
 
-def format_github_url_using_https(github_url):
+def format_github_url_using_https(github_url: str):
     ssh_base = "git@"
     https_base = "https://"
     # If the URL is formatted for SSH, convert, otherwise, do nothing
@@ -19,25 +19,37 @@ def format_github_url_using_https(github_url):
     return github_url
 
 
-def get_git_version_info():
+class GitInfo(TypedDict):
+    repo: str
+    commit: str
+    commit_abbrev: str
+    branch: str
+
+
+def get_git_version_info() -> Optional[GitInfo]:
     logger.debug(get_git_version_info.__name__)
 
-    commit = os.getenv("GIT_COMMIT", "")
-    if commit != "":
-        commit_abbrev = commit[:settings.SHA_ABBREV_LENGTH]
-    else:
-        commit_abbrev = ""
+    commit = os.getenv("GIT_COMMIT", None)
+    branch = os.getenv("GIT_BRANCH", None)
+    repo = os.getenv("GIT_REPO", None)
+
+    if not repo or not branch or not commit:
+        return None
+
+    commit_abbrev = (
+        commit[:settings.SHA_ABBREV_LENGTH]
+        if len(commit) > settings.SHA_ABBREV_LENGTH else commit
+    )
 
     # Only include the branch name and not remote info
-    branch = os.getenv("GIT_BRANCH", "").split('/')[-1]
+    branch = branch.split('/')[-1]
 
-    git_version = {
-        "repo": format_github_url_using_https(os.getenv("GIT_REPO", "")),
+    return {
+        "repo": format_github_url_using_https(repo),
         "commit": commit,
         "commit_abbrev": commit_abbrev,
         "branch": branch
     }
-    return git_version
 
 
 def search_key_for_resource_value(my_dict, search_for):

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -49,7 +49,7 @@
                     {{ flatpages.first.content|safe }}
                 </td>
                 {% endif %}
-                {% if user.is_superuser %}
+                {% if user.is_superuser and git_version %}
                 <td style="text-align: left">
                     Git version:
                     <a href="{{ git_version.repo }}/commit/{{ git_version.commit }}">{{ git_version.commit_abbrev }}</a>


### PR DESCRIPTION
This PR follows up on PR #1204 to better handle the case in the UI of when no Git variables are provided. Ultimately, `GIT_REPO`, `GIT_BRANCH`, and `GIT_COMMIT` need to be defined as environment variables; if they are not, the template will not show that block of info in the footer. This is a minor improvement building on top of @andrew-gardener's work. The PR aims to resolve issue #1236.