### PR TITLE
Remove `d3.event.preventDefault` to resolve console errors in Resources Accessed (#1298)

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -252,7 +252,6 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
 
     // Make sure the page doesnt scroll
     d3.event.stopPropagation()
-    d3.event.preventDefault()
     // Move the brush
     gBrush.call(brush.move, [topSection, topSection + size])
   }


### PR DESCRIPTION
This PR aims to resolve #1298.

I don't know exactly the cause of this error, the scrolling stuff in this `d3` component is confusing to me. However the errors seem to go away when it's removed, and I didn't see any differences in the view. The change could use some testing though, and I think @justin0022 and @pushyamig worked on this code last.

I am still seeing a warning message in the console saying "[Violation] 'wheel' handler took 947ms", but it seems to be happening with or without this change, so it seems to be NOT related.
