### PR TITLE
Fixes #1304 Ability to add/edit deployment ids though the django admin panel

### DIFF
--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -96,6 +96,8 @@
     "STUDENT_DASHBOARD_LTI": false,
     "/*  LTI 1.3 configuration":"*/",
     "/*  The first key of LTI_CONFIG is the Canvas URL (production, beta, or test)":"*/",
+    "/*  Note: If you leave this undefined, it will be available for configuration in the admin interface":"*/",
+    "/*  If you define any settings here, these will take effect instead of the admin settings":"*/",
     "LTI_CONFIG": {
         "https://canvas.instructure.com": [
             {

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -441,6 +441,9 @@ if STUDENT_DASHBOARD_LTI:
     LTI_CONFIG = ENV.get('LTI_CONFIG', {})
     LTI_CONFIG_TEMPLATE_PATH = ENV.get('LTI_CONFIG_TEMPLATE_PATH')
     LTI_CONFIG_DISABLE_DEPLOYMENT_ID_VALIDATION = ENV.get('LTI_CONFIG_DISABLE_DEPLOYMENT_ID_VALIDATION', False)
+    # If LTI_CONFIG is not defined then add the admin interface config
+    if not LTI_CONFIG:
+        INSTALLED_APPS += ('pylti1p3.contrib.django.lti1p3_tool_config',)
 
 # This is used to fix ids from Canvas Data which are incremented by some large number
 CANVAS_DATA_ID_INCREMENT = ENV.get("CANVAS_DATA_ID_INCREMENT", 17700000000000000)


### PR DESCRIPTION
This draft is working so far, but currently it's either/or. You define a config in the config file or in the admin panel.

This presents somewhat of a chicken/egg problem. Since you'd need to have the entry in the database or have a local admin account to login to add the initial configuration. I'm not sure the best way to handle this yet. 