### PR TITLE
Add an event log report to the Django admin & Disable editing, removing and adding event and cron logs

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -99,10 +99,10 @@ class MyLALogAdmin(ExportMixin, LogAdmin):
     def has_add_permission(request):
         return False
     @staticmethod
-    def has_change_permission(request):
+    def has_change_permission(request, obj=None):
         return False
     @staticmethod
-    def has_delete_permission(request):
+    def has_delete_permission(request, obj=None):
         return False
 
 # This is local class for Cron that disables add
@@ -112,10 +112,10 @@ class MyLACronJobLogAdmin(CronJobLogAdmin):
     def has_add_permission(request):
         return False
     @staticmethod
-    def has_change_permission(request):
+    def has_change_permission(request, obj=None):
         return False
     @staticmethod
-    def has_delete_permission(request):
+    def has_delete_permission(request, obj=None):
         return False
 
 admin.site.register(AcademicTerms, TermAdmin)
@@ -125,6 +125,6 @@ admin.site.register(Course, CourseAdmin)
 admin.site.unregister(Log)
 admin.site.register(Log, MyLALogAdmin)
 
-# Remove the pinax cron and add ours
+# Remove the django-cron CronJobLog and add ours
 admin.site.unregister(CronJobLog)
-admin.site.register(CronJobLog,MyLACronJobLogAdmin)
+admin.site.register(CronJobLog, MyLACronJobLogAdmin)

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -101,6 +101,9 @@ class MyLALogAdmin(ExportMixin, LogAdmin):
     @staticmethod
     def has_change_permission(request):
         return False
+    @staticmethod
+    def has_delete_permission(request):
+        return False
 
 # This is local class for Cron that disables add
 class MyLACronJobLogAdmin(CronJobLogAdmin):
@@ -110,6 +113,9 @@ class MyLACronJobLogAdmin(CronJobLogAdmin):
         return False
     @staticmethod
     def has_change_permission(request):
+        return False
+    @staticmethod
+    def has_delete_permission(request):
         return False
 
 admin.site.register(AcademicTerms, TermAdmin)

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -91,29 +91,33 @@ class LogResource(resources.ModelResource):
     class Meta:
         model = Log
 
-# This is a local class for logs that adds in Export and disables some actions on the admin
+# This is a local class for LogAdmin that adds in export and disables adding and removing logs
 class MyLALogAdmin(ExportMixin, LogAdmin):
     resource_class = LogResource
     # Remove adding and editing for logs
     @staticmethod
     def has_add_permission(request):
         return False
+
     @staticmethod
     def has_change_permission(request, obj=None):
         return False
+    
     @staticmethod
     def has_delete_permission(request, obj=None):
         return False
 
-# This is local class for Cron that disables add
+# This is local class for CronJobLogAdmin that disables adding and removing cron logs
 class MyLACronJobLogAdmin(CronJobLogAdmin):
     # Remove adding and editing for cron logs
     @staticmethod
     def has_add_permission(request):
         return False
+    
     @staticmethod
     def has_change_permission(request, obj=None):
         return False
+    
     @staticmethod
     def has_delete_permission(request, obj=None):
         return False

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -95,17 +95,21 @@ class LogResource(resources.ModelResource):
 class MyLALogAdmin(ExportMixin, LogAdmin):
     resource_class = LogResource
     # Remove adding and editing for logs
-    def has_add_permission(self, request, obj=None):
+    @staticmethod
+    def has_add_permission(request):
         return False
-    def has_change_permission(self, request, obj=None):
+    @staticmethod
+    def has_change_permission(request):
         return False
 
 # This is local class for Cron that disables add
 class MyLACronJobLogAdmin(CronJobLogAdmin):
     # Remove adding and editing for cron logs
-    def has_add_permission(self, request, obj=None):
+    @staticmethod
+    def has_add_permission(request):
         return False
-    def has_change_permission(self, request, obj=None):
+    @staticmethod
+    def has_change_permission(request):
         return False
 
 admin.site.register(AcademicTerms, TermAdmin)

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -118,6 +118,7 @@ INSTALLED_APPS = [
     'django_mysql',
     'constance',
     'constance.backends.database',
+    'import_export',
 ]
 
 # The order of this MIDDLEWARE is important

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ django-mysql==3.12.0
 django-constance[database]==2.8.0
 django-webpack-loader==1.1.0
 django-csp==3.7
+django-import-export==2.6.0
 
 # graphql
 graphene-django==2.15.0


### PR DESCRIPTION
Disable editing, removing and adding event logs and cron logs

Fixes #1253 and Fixes #1325

This adds a second page where you can select the output format(s) for all events
![image](https://user-images.githubusercontent.com/27447/134575781-008eef6c-c98b-43f6-a744-ea29f13d12a3.png)

It looks like we can add an export for selecting individual events but I don't know how useful that would be.

When I was in there I saw this issue #1325 that I fixed along with this to disable add/edit of events.