### PR TITLE
issue_1379 added the platform option for MySQL 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
 
   mysql:
     image: mysql:5.7
+    platform: linux/amd64
     restart: on-failure
     command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     env_file:


### PR DESCRIPTION
Added the platform option in docker-compose.yml, since the current MySQL image does not support ARM containers (Apple M1 is an ARM-based system).

