### PR TITLE
#1408 - Remove Vim

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -9,10 +9,10 @@ RUN npm install
 
 # NOTE: assets/ likely to change between dev builds
 COPY assets /usr/src/app/assets
-RUN npm run prod 
+RUN npm run prod
 
 # This is to find and remove symlinks that break some Docker builds.
-# We need these later we'll just uncompress them 
+# We need these later we'll just uncompress them
 # Put them in node_modules as this directory isn't masked by docker-compose
 # Also remove src and the symlinks afterward
 RUN apt-get update && \
@@ -40,7 +40,7 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential default-libmysqlclient-dev  libpq-dev netcat vim-tiny jq python3-dev xmlsec1 cron git && \
+    build-essential default-libmysqlclient-dev libpq-dev netcat jq python3-dev xmlsec1 cron git && \
     apt-get upgrade -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -8,10 +8,10 @@ RUN npm install
 
 # NOTE: assets/ likely to change between dev builds
 COPY assets /usr/src/app/assets
-RUN npm run prod 
+RUN npm run prod
 
 # This is to find and remove symlinks that break some Docker builds.
-# We need these later we'll just uncompress them 
+# We need these later we'll just uncompress them
 # Put them in node_modules as this directory isn't masked by docker-compose
 # Also remove src and the symlinks afterward
 RUN apt-get update && \
@@ -39,7 +39,7 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential default-libmysqlclient-dev  libpq-dev netcat vim-tiny jq python3-dev xmlsec1 cron git && \
+    build-essential default-libmysqlclient-dev libpq-dev netcat jq python3-dev xmlsec1 cron git && \
     apt-get upgrade -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
As specified in #1408, to address vulnerability CVE-2021-3973, remove Vim, which was probably installed for debugging purposes.

Closes #1408.

## Test plan
* Start MyLA with `docker compose up --build`
* Access application and perform basic functions
* Check logs for error messages
* *Optional*: Start a shell with `docker compose exec -it web /bin/sh` and verify that Vim is not installed.  E.g.…
  * Try running `vi`, `vim-tiny`, etc.
  * Use `apt list` to view a list of installed packages and verify that Vim is not included among them

<img src="https://user-images.githubusercontent.com/20786/187272429-c661ec83-325c-400a-bb11-16f0fa293c8a.jpg" alt="1408" width="400px">