### PR TITLE
Allow for environment variable override of `env.hjson` values (#787)

### DIFF
--- a/config/env_sample.hjson
+++ b/config/env_sample.hjson
@@ -95,8 +95,6 @@
     # strings for construct file download url
     "CANVAS_FILE_PREFIX": "https://umich.instructure.com/files/",
     "CANVAS_FILE_POSTFIX": "/download?download_frd=1",
-    # Paths to Google BigQuery credential json file
-    "GOOGLE_APPLICATION_CREDENTIALS": "/secrets/bq_cred.json",
     # LTI Configuration
     # LTI is disabled by default
     "ENABLE_LTI": false,

--- a/config/env_sample.hjson
+++ b/config/env_sample.hjson
@@ -2,8 +2,8 @@
     # Required to set this with some value
     # Run the code here to generate https://raw.githubusercontent.com/openwisp/ansible-openwisp2/master/files/generate_django_secret_key.py
     "DJANGO_SECRET_KEY": "<Generate Secret Key>",
-    # Set the Timezone for the container (must rebuild if changed)
-    "TZ": "America/Detroit",
+    # Sets the time zone for Django (defaults to environment variable TZ, which defaults to "America/Detroit")
+    # "TIME_ZONE": "America/Detroit",
     # CSV List of hosts allowed, no spaces in between commas
     "ALLOWED_HOSTS": [
         "127.0.0.1",

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -259,7 +259,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = ENV.get("TIME_ZONE", ENV.get("TZ", "America/Detroit"))
+TIME_ZONE = ENV.get("TIME_ZONE", os.getenv("TZ", "America/Detroit"))
 
 USE_I18N = True
 

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -43,7 +43,7 @@ def apply_env_overrides(env: Dict[str, Any], environ: os._Environ) -> Dict[str, 
                 logger.debug('Value was valid JSON; saved parsed data in env object.')
             except json.JSONDecodeError:
                 pass
-            ENV[key] = os_value
+            env_copy[key] = os_value
             logger.debug(f'ENV value for "{key}" overridden')
             logger.debug(f'key: {key}; os_value: {os_value}')
     return env_copy

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -40,8 +40,9 @@ def apply_env_overrides(env: Dict[str, Any], environ: os._Environ) -> Dict[str, 
             os_value = environ[key]
             try:
                 os_value = json.loads(os_value)
-                logger.debug('Value was valid JSON; saved parsed data in env object.')
+                logger.debug('Value was valid JSON; replaced value with parsed data.')
             except json.JSONDecodeError:
+                logger.debug('Value was not JSON; kept the value as is.')
                 pass
             env_copy[key] = os_value
             logger.debug(f'ENV value for "{key}" overridden')

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -43,7 +43,6 @@ def apply_env_overrides(env: Dict[str, Any], environ: os._Environ) -> Dict[str, 
                 logger.debug('Value was valid JSON; replaced value with parsed data.')
             except json.JSONDecodeError:
                 logger.debug('Value was not JSON; kept the value as is.')
-                pass
             env_copy[key] = os_value
             logger.debug(f'ENV value for "{key}" overridden')
             logger.debug(f'key: {key}; os_value: {os_value}')

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -44,7 +44,7 @@ def apply_env_overrides(env: Dict[str, Any], environ: os._Environ) -> Dict[str, 
             except json.JSONDecodeError:
                 pass
             ENV[key] = os_value
-            logger.info(f'ENV value for "{key}" overridden')
+            logger.debug(f'ENV value for "{key}" overridden')
             logger.debug(f'key: {key}; os_value: {os_value}')
     return env_copy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,13 @@ More details on certain topics are provided below.
 > **Note:** If you were using a prior version of MyLA, there is a utility `env_to_json.py` to help convert your configuration.
 > Running `python env_to_json.py > config/env.hjson` should create your new config file from your `.env` file.
 
+There are two other ways to control configuration in `env.hjson` using environment variables.
+1. Set the environment variable `ENV_JSON` to be a valid JSON document
+containing all the desired key-value pairs.
+2. Override individual values by setting an environment variable with a given key name.
+Note that only outermost keys are supported. If the value you want to change is in a nested object,
+you will have to override the entire value associated with the outer key.
+
 ### LTI v1.3
 
 MyLA supports LTI 1.3, using [pylti1.3](https://github.com/dmitry-viskov/pylti1.3).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,8 +20,9 @@ There are two other ways to control configuration in `env.hjson` using environme
 1. Set the environment variable `ENV_JSON` to be a valid JSON document
 containing all the desired key-value pairs.
 2. Override individual values by setting an environment variable with a given key name.
-Note that only outermost keys are supported. If the value you want to change is in a nested object,
-you will have to override the entire value associated with the outer key.
+Note that only outermost keys are supported.
+If the value you want to change is in a nested object or array,
+you will have to provide a new version of all the nested data as a JSON string for the override value.
 
 ### LTI v1.3
 


### PR DESCRIPTION
This PR aims to resolve #787.

Test plan:
1) In your `.env` or `docker-compose.yml`, add `ROOT_LOG_LEVEL=DEBUG`, then any additional `env.hjson` keys you'd like to override.
2) Start up the server; note the log messages about overrides.
3) Make sure the new values are being properly used.