### PR TITLE
issue #1443 added the sis_name retrieval back to user query for UDW cron query

### DIFF
--- a/config/cron.hjson
+++ b/config/cron.hjson
@@ -9,14 +9,14 @@
         with
         enroll_data as (select id as enroll_id, user_id, type, course_id from enrollment_dim where course_id in %(course_ids)s
                         and type in ('StudentEnrollment', 'TaEnrollment', 'TeacherEnrollment') and workflow_state= 'active'),
-        user_info as (select p.sis_user_id, u.id as user_id, u.global_canvas_id
+        user_info as (select p.unique_name, p.sis_user_id, u.id as user_id, u.global_canvas_id
                     from (SELECT ROW_NUMBER() OVER (PARTITION BY user_id order by sis_user_id asc) AS row_number, * FROM pseudonym_dim) as p
                     join user_dim u on u.id = p.user_id WHERE row_number = 1),
-        user_enroll as (select u.sis_user_id, u.user_id, e.enroll_id, e.course_id as course_id,
+        user_enroll as (select u.unique_name, u.sis_user_id, u.user_id, e.enroll_id, e.course_id as course_id,
                         u.global_canvas_id, e.type from enroll_data e join user_info u on e.user_id= u.user_id),
         course_fact as (select enrollment_id, course_id, current_score, final_score from course_score_fact
                         where course_id in %(course_ids)s),
-        final as (select cast(u.global_canvas_id as BIGINT) as user_id,
+        final as (select cast(u.global_canvas_id as BIGINT) as user_id, u.unique_name as sis_name,
                 u.course_id as course_id, c.current_score as current_grade, c.final_score as final_grade,
                 u.type as enrollment_type
                 from user_enroll u left join course_fact c on u.enroll_id= c.enrollment_id and u.course_id = c.course_id)

--- a/config/cron_udp.hjson
+++ b/config/cron_udp.hjson
@@ -12,6 +12,9 @@
             +
             cast(p2.lms_ext_id as bigint)
             ) as user_id,
+            case
+                when pe.email_address is not null then lower(split_part(pe.email_address , '@', 1))
+                else p2.sis_ext_id end as sis_name,
             cast(co.lms_int_id as bigint) as course_id,
             cg.le_current_score as current_grade,
             cg.le_final_score as final_grade,


### PR DESCRIPTION
This is partial revert of cron.hjson change in #1392: restored sis_name, and still leave out the user's name field.

Will file a UDP request for including Canvas user login_id in UDP, so that we can retrieve the sis_name field in UDP cron, too