### PR TITLE
DRAFT: Switching mysqlclient to mysql-connector-python

### DIFF
--- a/dashboard/common/db_util.py
+++ b/dashboard/common/db_util.py
@@ -21,7 +21,7 @@ BACKENDS_PATH = 'django.db.backends.'
 
 
 class DjangoDBParams(TypedDict):
-    ENGINE: Literal['django.db.backends.mysql', 'django.db.backends.postgresql']
+    ENGINE: Literal['mysql.connector.django', 'django.db.backends.postgresql']
     NAME: str
     USER: str
     PASSWORD: str

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -221,7 +221,7 @@ WSGI_APPLICATION = 'dashboard.wsgi.application'
 DATABASES = {
     'default': {
         **{
-            'ENGINE': 'django.db.backends.mysql',
+            'ENGINE': 'mysql.connector.django',
             'NAME': 'student_dashboard',
             'USER': 'student_dashboard_user',
             'PASSWORD': 'student_dashboard_password',

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential default-libmysqlclient-dev libpq-dev netcat jq python3-dev xmlsec1 cron git && \
+    build-essential libpq-dev netcat jq python3-dev xmlsec1 cron git && \
     apt-get upgrade -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,8 @@ pangres==4.1.2
 
 SQLAlchemy==1.4.22
 psycopg2==2.9.1
-mysqlclient==2.0.3
+#mysqlclient==2.0.3
+mysql-connector-python==8.0.31
 google-cloud-bigquery[pandas]==3.3.2
 
 debugpy==1.4.1


### PR DESCRIPTION
This is done to resolve some security issues in the mariadb packages and use the pure Python MySQL driver. 

You have to update your env file in your config to use this different Django Engine. There isn't an issue related to this yet but I'll create one soon. 

Here's some [discussion of the performance of this. ](https://gist.github.com/methane/90ec97dda7fa9c7c4ef1?permalink_comment_id=4154254#gistcomment-4154254)

This is not fully tested so is a draft for now, but does startup. 


