### PR TITLE
Fixes #1454 (Fix 2) - Switch MySQL to library version with less security issues.

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash && \
     apt install -y --no-install-recommends libmariadb-dev
 
 # Clean up anything we don't need anymore
-RUN apt-get purge -y curl libcurl4 libcurl3-gnutls && \
+RUN apt-get purge -y curl libcurl4 && \
     apt autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -39,8 +39,17 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential default-libmysqlclient-dev libpq-dev netcat jq python3-dev xmlsec1 cron git && \
-    apt-get upgrade -y && \
+        build-essential curl apt-transport-https libpq-dev netcat jq python3-dev xmlsec1 cron git && \
+    apt-get upgrade -y
+
+# Install MariaDB from the mariadb repository rather than using Debians 
+# https://mariadb.com/kb/en/mariadb-package-repository-setup-and-usage/
+RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash && \
+    apt install -y --no-install-recommends libmariadb-dev
+
+# Clean up anything we don't need anymore
+RUN apt-get purge -y curl libcurl4 && \
+    apt autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
* Don't remove libcurl3-gnutls since it's [needed for git.](https://packages.debian.org/bullseye/git)
* Apply changes to Dockerfile.openshift.