### PR TITLE
Disallow changing course canvas ID (#613)

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -94,7 +94,7 @@ class CourseAdmin(admin.ModelAdmin):
     def course_link(self, obj):
         return format_html('<a href="{}">Link</a>', obj.absolute_url)
 
-    def change_view(self, request, object_id, extra_content=None):
+    def change_view(self, request, object_id, form_url='', extra_content=None):
         self.readonly_fields = self.readonly_fields + ('canvas_id',)
         return super(CourseAdmin, self).change_view(request, object_id)
 

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -70,6 +70,7 @@ class TermAdmin(admin.ModelAdmin):
 class CourseAdmin(admin.ModelAdmin):
     inlines = [CourseViewOptionInline, ]
     form = CourseForm
+    fields = ('canvas_id', 'name', 'term', 'date_start', 'date_end', 'show_grade_counts', 'show_grade_type', 'data_last_updated')
     list_display = ('canvas_id', 'name', 'term', 'show_grade_counts', 'course_link', '_courseviewoption', 'data_last_updated')
     list_select_related = True
     readonly_fields = ('term', 'data_last_updated',)
@@ -92,6 +93,10 @@ class CourseAdmin(admin.ModelAdmin):
 
     def course_link(self, obj):
         return format_html('<a href="{}">Link</a>', obj.absolute_url)
+
+    def change_view(self, request, object_id, extra_content=None):
+        self.readonly_fields = self.readonly_fields + ('canvas_id',)
+        return super(CourseAdmin, self).change_view(request, object_id)
 
     # When saving the course, update the id based on canvas id
     def save_model(self, request, obj, form, change):


### PR DESCRIPTION
This PR aims to resolve #613. See my comment in the issue for rationale behind the solution. I left it so you can still create courses manually in the admin UI, but you can't edit the course ID after you create the course (it'll have to be deleted and re-created).

Resource(s):
- https://docs.djangoproject.com/en/4.1/ref/contrib/admin/
- https://stackoverflow.com/a/46063862