### PR TITLE
Make Resources Accessed chart keyboard accessible (#1190)

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -474,7 +474,7 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
     .call(truncate, resourceLabelWidth)
 
   // Add links and icons to Y axis
-  d3.selectAll('.axis--y .tick').each(function (d, i) {
+  d3.selectAll('.axis--y .tick').each(function (d) {
     // Have to use ES5 function to correctly use `this` keyword
     const link = d.split('|')[0]
     const name = d.split('|')[1]

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -192,7 +192,7 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
 
     bar.enter()
       .append('rect')
-      .attr('tabindex', d => d.index * 10 + 1)
+      .attr('tabindex', 0)
       .attr('y', d => mainYScale(d.resource_name))
       .attr('width', d => mainXScale(d.total_percent))
       .attr('height', mainYScale.bandwidth())
@@ -415,7 +415,7 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
     .text('Percentage of All Students in the Selected Grade Range')
     .style('font-size', '14px')
 
-  mainGroup.append('g')
+  mainGroup.insert('g', ':first-child')
     .attr('class', 'axis--y black-axis-line')
     .attr('transform', 'translate(0,0)')
     .call(mainYAxis)
@@ -456,13 +456,12 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
     // Have to use ES5 function to correctly use `this` keyword
     const link = d.split('|')[0]
     const name = d.split('|')[1]
-    const resourceDataIndex = resourceData.filter(rd => rd.resource_name === d)[0].index
     const a = d3.select(this.parentNode).append('a')
       .attr('title', name)
       .attr('target', '_blank')
       .attr('href', link)
       .attr('text-anchor', 'start')
-      .attr('tabindex', resourceDataIndex * 10)
+      .attr('tabindex', 0)
     a.node().appendChild(this)
 
     const icon = d.split('|')[2]

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -173,7 +173,6 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
     .attr('class', 'svgWrapper')
     .attr('width', availWidth)
     .attr('height', availHeight)
-    .attr('aria-hidden', 'true')
     .attr('transform', `translate(${margin.left}, ${margin.top})`)
     .on('wheel.zoom', scroll, { passive: true })
     .on('mousedown.zoom', null) // Override the center selection

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -326,8 +326,18 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
   function moveBrushOnFocus (event, dataKey) {
     const selection = d3.brushSelection(gBrush.node())
     const size = selection[1] - selection[0]
-    const miniY = miniYScale(dataKey) + miniYScale.step()
-    const newY = miniY > size ? miniY : size
+    const miniY = miniYScale(dataKey)
+    const step = miniYScale.step()
+    // Start brush at bar if brush size is less than two steps, otherwise put at the end minus steps
+    const newY = size < (step * 2)
+      ? miniY + size
+      // Use size if size is greater than or equal to bar plus two steps, otherwise use bar plus steps
+      : (miniY + step * 2) <= size
+          ? size
+          // Use two steps after bar if there is space, otherwise use one step
+          : miniY <= miniYScale.range()[1] - step
+            ? miniY + step * 2
+            : miniY + step
     const newSelection = [newY - size, newY]
     event.stopPropagation()
     gBrush.call(brush.move, newSelection)

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -474,7 +474,6 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
       .attr('href', link)
       .attr('text-anchor', 'start')
       .attr('tabindex', 0)
-      .attr('data-index', i)
       .on('focus', (e) => moveBrushOnFocus(e, d))
     a.node().appendChild(this)
 

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -201,7 +201,9 @@ function createResourceAccessChart ({ data, weekRange, gradeSelection, resourceT
         ? accessedResourceColor
         : notAccessedResourceColor
       )
+      .on('focus', toolTip.show)
       .on('mouseover', toolTip.show)
+      .on('blur', toolTip.hide)
       .on('mouseout', toolTip.hide)
       .append('foreignObject')
       .append('div')


### PR DESCRIPTION
This PR aims to resolve #1190.

To Do
- [x] Show tooltip on focus
- [x] Move brush/scroll when tabbing through chart
- [x] Move labels before bars in tab order
- [x] Evaluate click focus behavior (see [my comment here](https://github.com/tl-its-umich-edu/my-learning-analytics/pull/1472/files#r1086930662))