### PR TITLE
Fixes #1482 - Remove additional unused dev dependencies to reduce security impacts

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -62,8 +62,12 @@ COPY . .
 # Generate git version information
 RUN /code/scripts/git_version_info.sh
 
-# Clean up anything we don't need anymore
+# Clean up anything we don't need anymore.
+# Some of these can be purged completely, some of these just remove the package
 RUN apt-get purge -y git curl libcurl4 libcurl3-gnutls && \
+    apt-get remove -y linux-libc-dev && \
+# Keep these packages
+    apt-mark manual libmariadb3 mariadb-common && \
     apt autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -61,8 +61,12 @@ COPY . .
 # Generate git version information
 RUN bash -l -c ./scripts/git_version_info.sh
 
-# Clean up anything we don't need anymore
+# Clean up anything we don't need anymore.
+# Some of these can be purged completely, some of these just remove the package
 RUN apt-get purge -y git curl libcurl4 libcurl3-gnutls && \
+    apt-get remove -y linux-libc-dev && \
+# Keep these packages
+    apt-mark manual libmariadb3 mariadb-common && \
     apt autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This issue is really only coming up in the container service scan, not in the docker scan. 

Running `docker scan` before this does report more issues and dependencies though
Before: Tested 195 dependencies for known issues, found 97 issues.
After: Tested 137 dependencies for known issues, found 67 issues.

Verify that MyLA works as expected. 