### PR TITLE
remove reference to 'No Term' term from UDP course query

### DIFF
--- a/config/cron_udp.hjson
+++ b/config/cron_udp.hjson
@@ -162,12 +162,9 @@
             ka.lms_ext_id is not null
         order by id
         ''',
-     /* start_at and conclude_at contain only the date information, with time values truncated
-        Mapping all courses with a NULL term into the term called No Term
-     */
+     /* start_at and conclude_at contain only the date information, with time values truncated */
     "course":
         '''
-        WITH no_term_temp as (SELECT academic_term_id from entity.academic_term where name = 'No Term')
         SELECT
             cast(co2.lms_int_id as BIGINT) as id,
             cast(co2.lms_ext_id as BIGINT) as canvas_id,
@@ -179,14 +176,11 @@
             entity.course_offering co
             LEFT OUTER JOIN entity.academic_session as3 on (co.academic_session_id = as3.academic_session_id),
             keymap.course_offering co2,
-            keymap.academic_term at2,
-            no_term_temp
+            keymap.academic_term at2
             WHERE co2.lms_int_id in %(course_ids)s
             and co.course_offering_id = co2.id
             and (
                 (co.academic_session_id is null and co.academic_term_id is not null and (co.academic_term_id = at2.id))
-            or
-                (co.academic_session_id is null and co.academic_term_id is null and at2.id = no_term_temp.academic_term_id)
             or
                 (co.academic_session_id = as3.academic_session_id and at2.id = as3.academic_term_id)
             )


### PR DESCRIPTION
When are working with a UDP only implementation of MyLA it will not importing any course data for courses that it is installed for. The cron outputs the following:
```
[2023-03-13 11:00:59 -0400] [INFO] [cron.py:30] /code/config/cron_udp.hjson
[2023-03-13 11:00:59 -0400] [INFO] [cron.py:585] ** MyLA cron tab
[2023-03-13 11:00:59 -0400] [INFO] [cron.py:136] Course 42420000000111111 doesn't have an entry in data warehouse yet. It hasn't been updated locally, so skipping.
[2023-03-13 11:00:59 -0400] [INFO] [cron.py:136] Course 42420000000222222 doesn't have an entry in data warehouse yet. It hasn't been updated locally, so skipping.
[2023-03-13 11:00:59 -0400] [INFO] [cron.py:136] Course 42420000000333333 doesn't have an entry in data warehouse yet. It hasn't been updated locally, so skipping.
[2023-03-13 11:00:59 -0400] [INFO] [cron.py:136] Course 42420000000444444 doesn't have an entry in data warehouse yet. It hasn't been updated locally, so skipping.
```

Despite the course existing in the database:
```
        id         | canvas_id | enrollment_term_id |   name   |      start_at       |     conclude_at     
-------------------+-----------+--------------------+----------+---------------------+---------------------
 42420000000222222 |    222222 |  42420000000000222 | SS93K    | 2023-03-31 00:00:00 | 2023-05-19 00:00:00
 42420000000333333 |    333333 |  42420000000000222 | SG31     | 2023-01-24 00:00:00 | 2023-05-19 00:00:00
 42420000000444444 |    444444 |  42420000000000222 | SMM72A   | 2023-01-24 00:00:00 | 2023-04-23 00:00:00
 42420000000111111 |    111111 |  42420000000000001 | LAFS     | 2020-02-24 00:00:00 | 
```

This is due to the reference of the term named `No Term` in the `courses` query of the `cron_udp.hjson` config. By removing that we are able to successfully import courses attached to any term for MyLA.

This PR removes the reference for the `No Term` term that enabled us to successfully run the MyLA imports.