### PR TITLE
Fixes #1513 - Switch base image to (Debian) bookworm

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -30,7 +30,7 @@ RUN npm prune --production && \
     find node_modules -type d -name "examples" -print0 | xargs -0 rm -rf
 
 # FROM directive instructing base image to build upon
-FROM python:3.10-slim-bullseye AS app
+FROM python:3.10-slim-bookworm AS app
 
 # EXPOSE port 5000 to allow communication to/from server
 EXPOSE 5000
@@ -40,7 +40,7 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential curl apt-transport-https libpq-dev netcat jq python3-dev xmlsec1 cron git && \
+        build-essential curl apt-transport-https libpq-dev netcat-traditional jq python3-dev xmlsec1 cron git && \
     apt-get upgrade -y
 
 # Install MariaDB from the mariadb repository rather than using Debians 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -30,7 +30,7 @@ RUN npm prune --production && \
     find node_modules -type d -name "examples" -print0 | xargs -0 rm -rf
 
 # FROM directive instructing base image to build upon
-FROM python:3.10-slim AS app
+FROM python:3.10-slim-bullseye AS app
 
 # EXPOSE port 5000 to allow communication to/from server
 EXPOSE 5000

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -29,7 +29,7 @@ RUN npm prune --production && \
     find node_modules -type d -name "examples" -print0 | xargs -0 rm -rf
 
 # FROM directive instructing base image to build upon
-FROM docker-registry.default.svc:5000/openshift/python:3.10-slim-bullseye AS app
+FROM docker-registry.default.svc:5000/openshift/python:3.10-slim-bookworm AS app
 
 # EXPOSE port 5000 to allow communication to/from server
 EXPOSE 5000
@@ -39,7 +39,7 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential curl apt-transport-https libpq-dev netcat jq python3-dev xmlsec1 cron git && \
+        build-essential curl apt-transport-https libpq-dev netcat-traditional jq python3-dev xmlsec1 cron git && \
     apt-get upgrade -y
 
 # Install MariaDB from the mariadb repository rather than using Debians 

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -29,7 +29,7 @@ RUN npm prune --production && \
     find node_modules -type d -name "examples" -print0 | xargs -0 rm -rf
 
 # FROM directive instructing base image to build upon
-FROM docker-registry.default.svc:5000/openshift/python:3.10-slim AS app
+FROM docker-registry.default.svc:5000/openshift/python:3.10-slim-bullseye AS app
 
 # EXPOSE port 5000 to allow communication to/from server
 EXPOSE 5000


### PR DESCRIPTION
This is draft for now until MariaDB supports Bookworm 
https://mariadb.com/kb/en/installing-mariadb-deb-files/