### PR TITLE
`TIME_ZONE` config

### DIFF
--- a/config/env_sample.hjson
+++ b/config/env_sample.hjson
@@ -3,7 +3,7 @@
     # Run the code here to generate https://raw.githubusercontent.com/openwisp/ansible-openwisp2/master/files/generate_django_secret_key.py
     "DJANGO_SECRET_KEY": "<Generate Secret Key>",
     # Sets the time zone for Django (defaults to environment variable TZ, which defaults to "America/Detroit")
-    # "TIME_ZONE": "America/Detroit",
+    "TIME_ZONE": "America/Detroit",
     # CSV List of hosts allowed, no spaces in between commas
     "ALLOWED_HOSTS": [
         "127.0.0.1",


### PR DESCRIPTION
Fixes #1500.

* #1500 — To avoid problems with admins forgetting to set their time zone.  They may comment it out themselves if they want MyLA to use the value of the `TZ` environment variable.