### PR TITLE
I1515 node 18 upgrade

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,6 +1,6 @@
 # NOTE: When updating this file, also update Dockerfile.openshift
 # build react components for production mode
-FROM node:16-slim AS node-webpack
+FROM node:18-slim AS node-webpack
 WORKDIR /usr/src/app
 
 # NOTE: package.json and webpack.config.js not likely to change between dev builds
@@ -21,7 +21,7 @@ RUN apt-get update && \
     rm -rf /usr/src/app/assets/src
 
 # build node libraries for production mode
-FROM node:16-slim AS node-prod-deps
+FROM node:18-slim AS node-prod-deps
 
 WORKDIR /usr/src/app
 COPY --from=node-webpack /usr/src/app /usr/src/app

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,6 +1,6 @@
 # NOTE: When updating this file, also update Dockerfile.openshift
 # build react components for production mode
-FROM node:18-slim AS node-webpack
+FROM node:18-bullseye-slim AS node-webpack
 WORKDIR /usr/src/app
 
 # NOTE: package.json and webpack.config.js not likely to change between dev builds
@@ -21,7 +21,7 @@ RUN apt-get update && \
     rm -rf /usr/src/app/assets/src
 
 # build node libraries for production mode
-FROM node:18-slim AS node-prod-deps
+FROM node:18-bullseye-slim AS node-prod-deps
 
 WORKDIR /usr/src/app
 COPY --from=node-webpack /usr/src/app /usr/src/app

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # build react components for production mode
-FROM docker-registry.default.svc:5000/openshift/node:16-slim AS node-webpack
+FROM docker-registry.default.svc:5000/openshift/node:18-slim AS node-webpack
 WORKDIR /usr/src/app
 
 # NOTE: package.json and webpack.config.js not likely to change between dev builds
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /usr/src/app/assets/src
 
 # build node libraries for production mode
-FROM docker-registry.default.svc:5000/openshift/node:16-slim AS node-prod-deps
+FROM docker-registry.default.svc:5000/openshift/node:18-slim AS node-prod-deps
 
 WORKDIR /usr/src/app
 COPY --from=node-webpack /usr/src/app /usr/src/app

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # build react components for production mode
-FROM docker-registry.default.svc:5000/openshift/node:18-slim AS node-webpack
+FROM docker-registry.default.svc:5000/openshift/node:18-bullseye-slim AS node-webpack
 WORKDIR /usr/src/app
 
 # NOTE: package.json and webpack.config.js not likely to change between dev builds
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /usr/src/app/assets/src
 
 # build node libraries for production mode
-FROM docker-registry.default.svc:5000/openshift/node:18-slim AS node-prod-deps
+FROM docker-registry.default.svc:5000/openshift/node:18-bullseye-slim AS node-prod-deps
 
 WORKDIR /usr/src/app
 COPY --from=node-webpack /usr/src/app /usr/src/app


### PR DESCRIPTION
Fixes #1515 

I have updated to `18-bullseye-slim` upon some recommendation from Container service member Erik. 

> 18-bullseye-slim (which is currently in the registry) it's tied to a major version / specific Debian release.
> 
> We have been using 16-slim and alternative for it is 18-slim. it looks like [18-slim refers to Debian 12](https://hub.docker.com/_/node/) at the moment. If you wanted to pin it to that specific Debian release you could use 18-bookworm-slim. (Still might need to be imported to the OpenShift registry; but the idea is you avoid a situation in a couple years where 18-slim suddenly points to Debian 13, possibly breaking stuff.)

I Opted for bullseye as the current python version adaptation. Build are tested on MyLA Beta.  I am happy to change whatever version team agrees. 
