### PR TITLE
Fix ability to edit courses via the admin and `canvas_id` readonly logic, improve validation (#1509)

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -51,10 +51,11 @@ class CourseForm(forms.ModelForm):
         exclude = ()
 
     def clean(self):
-        canvas_id = self.cleaned_data.get('canvas_id')
-        if not canvas_id or not str(canvas_id).isdigit():
-            raise forms.ValidationError(
-                f"Course ID {canvas_id} must be an integer value")
+        # Only validate canvas_id on initial course creation
+        if self.instance.canvas_id is None:
+            canvas_id = self.cleaned_data.get('canvas_id')
+            if not str(canvas_id).isdigit():
+                raise forms.ValidationError('Canvas ID must be a positive integer value.')
         return self.cleaned_data
 
 


### PR DESCRIPTION
This PR fixes two bugs introduced by my work on PR #1468. It tries to do the following:

- Make courses editable again via the Django Admin interface by modifying the `clean` method in `CourseForm` to only validate `canvas_id` on course creation (`canvas_id` was always left out when editing since it was read only, which lead to errors being thrown).
- Fix a side-effect of the previous change where when a course was edited, subsequent creation of new courses still lableed `canvas_id` as read only. This was fixed by using the `get_readonly_fields` method rather than updating the instance variable.
- Try to improve the validation by disallowing zero and negative Canvas IDs. This wasn't in response to any bugs created by the previous change, but instead exploration of edge cases it makes sense to handle.

Test cases
- [ ] Create a new course with a valid course ID. Subsequently editing the course is possible (i.e. with the start and end times), but `canvas_id` is read only.
- [ ] Try to create a new course with the following invalid values. All should fail with appropriate error messages.
  - [ ] a decimal
  - [ ] a negative integer and/or decimal
  - [ ] zero
  - [ ] no entry
- [ ] Edit an existing course (maybe created automatically by a launch), and then try to create a new course. You should be able to edit `canvas_id` without issue.

If you think of more cases to test, please let me know.