### PR TITLE
I1542 GitHub branch fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
       version:
         description: 'Version'
         required: true
-        default: '2023MMDD'
+        default: 'YYYY.MINOR.MICRO'
 env:
   REPO_URL: ${{ github.repository }}
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,13 @@ on:
     branches: 
       - master
       - '[0-9][0-9][0-9][0-9].[0-9][0-9].*' # 2021.01.01
+      - i1542_*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        default: '2023MMDD'
   
 env:
   IMAGE_TAG: latest
@@ -14,7 +21,7 @@ env:
 jobs:
   build:
     # to test a feature, change the repo name to your github id
-    if: github.repository_owner == 'tl-its-umich-edu'
+    if: github.repository_owner == 'tl-its-umich-edu' || github.repository_owner == 'pushyamig'
     runs-on: ubuntu-latest
     steps:
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,27 @@
-name: Docker image CI
+name: MyLA Build/Release
 
 on:
   push:
     # takes muliple branch names
     branches: 
       - master
-      - '[0-9][0-9][0-9][0-9].[0-9][0-9].*' # 2021.01.01
-      - i1542_*
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].*' # 2021.01.x
+    tags:
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]' # 2021.01.01
+ 
   workflow_dispatch:
     inputs:
       version:
         description: 'Version'
         required: true
         default: '2023MMDD'
-  
 env:
-  IMAGE_TAG: latest
   REPO_URL: ${{ github.repository }}
     
 jobs:
   build:
     # to test a feature, change the repo name to your github id
-    if: github.repository_owner == 'tl-its-umich-edu' || github.repository_owner == 'pushyamig'
+    if: github.repository_owner == 'tl-its-umich-edu'
     runs-on: ubuntu-latest
     steps:
   
@@ -34,7 +34,7 @@ jobs:
       
       - name: build Docker image
         run: |
-          docker build . --tag ghcr.io/${{ env.REPO_URL }}:${{ env.IMAGE_TAG }}-${BRANCH_NAME}
+          docker build . --tag ghcr.io/${{ env.REPO_URL }}:${BRANCH_NAME}
       
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -45,5 +45,23 @@ jobs:
       
       - name: Push Docker image to GitHub Container Registry
         run: |
-          docker push ghcr.io/${{ env.REPO_URL }}:${{ env.IMAGE_TAG }}-${BRANCH_NAME}
+          docker push ghcr.io/${{ env.REPO_URL }}:${BRANCH_NAME}
+    
+  release: 
+     # Making sure that release only runs for tag pushes
+    if: startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'tl-its-umich-edu'
+    needs: build # This ensures the build job finishes successfully before starting this job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Draft Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
       
+


### PR DESCRIPTION
Fixes #1542 

This PR address following things
1. When a tag is created (via git tag 2017.01.01), auto builds and draft is created as  pre-release. https://github.com/pushyamig/my-learning-analytics/releases/tag/untagged-c851e0a7738c70bbe025
https://github.com/pushyamig/my-learning-analytics/actions/runs/6657871566
3. If user creates a release and publishes it from Github UI, This will trigger creation of tag, Github build is done all good.
 https://github.com/pushyamig/my-learning-analytics/releases/tag/1820.01.01
https://github.com/pushyamig/my-learning-analytics/actions/runs/6658577408
4. Now the branches/tags are tagged as `master`, `2023.01.x`, `2023.01.01`
https://github.com/pushyamig/my-learning-analytics/pkgs/container/my-learning-analytics
![Screenshot 2023-10-26 at 3 14 52 PM](https://github.com/tl-its-umich-edu/my-learning-analytics/assets/8579775/f6a13946-1b73-42a9-a3d8-380f6e3e68fb)

6.  You can also run any Build manually from UI
https://github.com/pushyamig/my-learning-analytics/actions/workflows/main.yml
![Screenshot 2023-10-26 at 3 12 42 PM](https://github.com/tl-its-umich-edu/my-learning-analytics/assets/8579775/20128489-ff58-48ff-9680-4e5b07716ab2)

To test these various scenarios, Take the main.yml and commit to master branch so that you could see the changes. Make sure you change the main.yml to point to your github repo and not `tl-its-umich.edu`