### PR TITLE
#1250: Add patterns to Resource Access visualizations

### DIFF
--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -393,10 +393,10 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .on('mousedown.brush', brushcenter)
     .on('touchstart.brush', brushcenter, { passive: true })
 
-  const defs = svg.append('defs')
+  const svgDefinitions = svg.append('defs')
 
   // Clips
-  defs.append('defs')
+  svgDefinitions.append('defs')
     .append('clipPath')
     .attr('id', 'clip')
     .append('rect')
@@ -405,7 +405,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('height', mainHeight)
 
   // Pattern for not accessed: black stripes on gray background
-  defs.append('pattern')
+  svgDefinitions.append('pattern')
     .attr('id', 'notAccessedPattern')
     .attr('width', 10)
     .attr('height', 10)

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -404,19 +404,9 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('width', mainWidth + mainMargin.left)
     .attr('height', mainHeight)
 
-  // Pattern
+  // Pattern for accessed: white dots on blue background
   defs.append('pattern')
     .attr('id', 'accessed-pattern')
-    // .attr('width', 10)
-    // .attr('height', 10)
-    // .attr('patternUnits', 'userSpaceOnUse')
-    // .attr('patternTransform', 'rotate(45)')
-    // .append('rect')
-    // .attr('width', 15)
-    // .attr('height', 10)
-    // .attr('stroke', 'white')
-    // .attr('stroke-width',2)
-    // .attr('transform', 'translate(-2,0)')
     .attr('width', 8)
     .attr('height', 8)
     .attr('patternUnits', 'userSpaceOnUse')
@@ -431,6 +421,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('fill', 'white')
     .attr('transform', 'translate(0,2)')
 
+  // Pattern for not accessed: black stripes on gray background
   defs.append('pattern')
     .attr('id', 'not-accessed-pattern')
     .attr('width', 10)
@@ -446,8 +437,6 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('width', 2)
     .attr('height', 10)
     .attr('fill', 'black')
-
-
 
   // Inject data
   // Domain

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -396,7 +396,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
   const svgDefinitions = svg.append('defs')
 
   // Clips
-  svgDefinitions.append('defs')
+  svgDefinitions
     .append('clipPath')
     .attr('id', 'clip')
     .append('rect')
@@ -405,7 +405,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('height', mainHeight)
 
   // Pattern for not accessed: black stripes on gray background
-  svgDefinitions.append('pattern')
+  svgDefinitions
+    .append('pattern')
     .attr('id', 'notAccessedPattern')
     .attr('width', 10)
     .attr('height', 10)
@@ -415,7 +416,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('width', 10)
     .attr('height', 10)
     .attr('fill', notAccessedResourceColor)
-  defs.select('#notAccessedPattern')
+  svgDefinitions.select('#notAccessedPattern')
     .append('rect')
     .attr('width', 2)
     .attr('height', 10)

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -44,7 +44,7 @@ function appendLegend (svg) {
   const legendY = -50
 
   const legendLabels = [
-    ['Resources I haven\'t viewed', 'url(#not-accessed-pattern)'],
+    ['Resources I haven\'t viewed', 'url(#notAccessedPattern)'],
     ['Resources I\'ve viewed', accessedResourceColor]
   ]
 
@@ -190,7 +190,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('class', 'bar')
       .attr('fill', d => d.self_access_count > 0
         ? accessedResourceColor
-        : 'url(#not-accessed-pattern)'
+        : 'url(#notAccessedPattern)'
       )
       .on('focus', (e, d) => {
         moveBrushOnFocus(e, d.resource_name)
@@ -286,7 +286,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     d3.select('.miniGroup').selectAll('.bar')
       .style('fill', d => d.self_access_count > 0
         ? accessedResourceColor
-        : 'url(#not-accessed-pattern)'
+        : 'url(#notAccessedPattern)'
       )
       .style('opacity', d => selected.includes(d.resource_name)
         ? 1
@@ -393,7 +393,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .on('mousedown.brush', brushcenter)
     .on('touchstart.brush', brushcenter, { passive: true })
 
-  let defs = svg.append('defs');
+  const defs = svg.append('defs')
 
   // Clips
   defs.append('defs')
@@ -406,7 +406,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
   // Pattern for not accessed: black stripes on gray background
   defs.append('pattern')
-    .attr('id', 'not-accessed-pattern')
+    .attr('id', 'notAccessedPattern')
     .attr('width', 10)
     .attr('height', 10)
     .attr('patternUnits', 'userSpaceOnUse')
@@ -414,8 +414,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .append('rect')
     .attr('width', 10)
     .attr('height', 10)
-    .attr('fill', notAccessedResourceColor) 
-  defs.select('#not-accessed-pattern')
+    .attr('fill', notAccessedResourceColor)
+  defs.select('#notAccessedPattern')
     .append('rect')
     .attr('width', 2)
     .attr('height', 10)
@@ -464,7 +464,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('class', 'bar')
     .attr('fill', d => d.self_access_count > 0
       ? accessedResourceColor
-      : 'url(#not-accessed-pattern)'
+      : 'url(#notAccessedPattern)'
     )
 
   // Add brush to main chart

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -38,14 +38,14 @@ const toolTip = tip.attr('class', 'd3-tip')
   })
 
 function appendLegend (svg) {
-  const legendBoxLength = 10
-  const legendBoxTextInterval = 15
+  const legendBoxLength = 13
+  const legendBoxTextInterval = 20
   const legendInterval = 20
   const legendY = -50
 
   const legendLabels = [
-    ['Resources I haven\'t viewed', notAccessedResourceColor],
-    ['Resources I\'ve viewed', accessedResourceColor]
+    ['Resources I haven\'t viewed', 'url(#not-accessed-pattern)'],
+    ['Resources I\'ve viewed', 'url(#accessed-pattern)']
   ]
 
   const legend = svg.select('.mainGroupWrapper').append('g')
@@ -189,8 +189,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('height', mainYScale.bandwidth())
       .attr('class', 'bar')
       .attr('fill', d => d.self_access_count > 0
-        ? accessedResourceColor
-        : notAccessedResourceColor
+        ? 'url(#accessed-pattern)'
+        : 'url(#not-accessed-pattern)'
       )
       .on('focus', (e, d) => {
         moveBrushOnFocus(e, d.resource_name)
@@ -210,7 +210,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .enter()
       .append('text')
       .attr('class', 'label')
-      .attr('x', d => mainXScale(d.total_percent) + 3 + mainMargin.left)
+      .attr('x', d => mainXScale(d.total_percent) + 40 + mainMargin.left)
       .attr('y', d => mainYScale(d.resource_name) + mainYScale.bandwidth() / 2 + mainMargin.top)
       .attr('dx', -10)
       .attr('dy', '.35em')
@@ -285,8 +285,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
     d3.select('.miniGroup').selectAll('.bar')
       .style('fill', d => d.self_access_count > 0
-        ? accessedResourceColor
-        : notAccessedResourceColor
+        ? 'url(#accessed-pattern)'
+        : 'url(#not-accessed-pattern)'
       )
       .style('opacity', d => selected.includes(d.resource_name)
         ? 1
@@ -393,14 +393,61 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .on('mousedown.brush', brushcenter)
     .on('touchstart.brush', brushcenter, { passive: true })
 
+  let defs = svg.append('defs');
+
   // Clips
-  svg.append('defs')
+  defs.append('defs')
     .append('clipPath')
     .attr('id', 'clip')
     .append('rect')
     .attr('x', -mainMargin.left)
     .attr('width', mainWidth + mainMargin.left)
     .attr('height', mainHeight)
+
+  // Pattern
+  defs.append('pattern')
+    .attr('id', 'accessed-pattern')
+    // .attr('width', 10)
+    // .attr('height', 10)
+    // .attr('patternUnits', 'userSpaceOnUse')
+    // .attr('patternTransform', 'rotate(45)')
+    // .append('rect')
+    // .attr('width', 15)
+    // .attr('height', 10)
+    // .attr('stroke', 'white')
+    // .attr('stroke-width',2)
+    // .attr('transform', 'translate(-2,0)')
+    .attr('width', 8)
+    .attr('height', 8)
+    .attr('patternUnits', 'userSpaceOnUse')
+    .append('rect')
+    .attr('width', 8)
+    .attr('height', 8)
+    .attr('fill', accessedResourceColor)
+  defs.select('#accessed-pattern')
+    .append('rect')
+    .attr('width', 2.5)
+    .attr('height', 2.5)
+    .attr('fill', 'white')
+    .attr('transform', 'translate(0,2)')
+
+  defs.append('pattern')
+    .attr('id', 'not-accessed-pattern')
+    .attr('width', 10)
+    .attr('height', 10)
+    .attr('patternUnits', 'userSpaceOnUse')
+    .attr('patternTransform', 'rotate(45)')
+    .append('rect')
+    .attr('width', 10)
+    .attr('height', 10)
+    .attr('fill', notAccessedResourceColor) 
+  defs.select('#not-accessed-pattern')
+    .append('rect')
+    .attr('width', 2)
+    .attr('height', 10)
+    .attr('fill', 'black')
+
+
 
   // Inject data
   // Domain
@@ -444,8 +491,8 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('height', miniYScale.bandwidth())
     .attr('class', 'bar')
     .attr('fill', d => d.self_access_count > 0
-      ? accessedResourceColor
-      : notAccessedResourceColor
+      ? 'url(#accessed-pattern)'
+      : 'url(#not-accessed-pattern)'
     )
 
   // Add brush to main chart

--- a/assets/src/components/d3/createResourceAccessChart.js
+++ b/assets/src/components/d3/createResourceAccessChart.js
@@ -45,7 +45,7 @@ function appendLegend (svg) {
 
   const legendLabels = [
     ['Resources I haven\'t viewed', 'url(#not-accessed-pattern)'],
-    ['Resources I\'ve viewed', 'url(#accessed-pattern)']
+    ['Resources I\'ve viewed', accessedResourceColor]
   ]
 
   const legend = svg.select('.mainGroupWrapper').append('g')
@@ -189,7 +189,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
       .attr('height', mainYScale.bandwidth())
       .attr('class', 'bar')
       .attr('fill', d => d.self_access_count > 0
-        ? 'url(#accessed-pattern)'
+        ? accessedResourceColor
         : 'url(#not-accessed-pattern)'
       )
       .on('focus', (e, d) => {
@@ -285,7 +285,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
 
     d3.select('.miniGroup').selectAll('.bar')
       .style('fill', d => d.self_access_count > 0
-        ? 'url(#accessed-pattern)'
+        ? accessedResourceColor
         : 'url(#not-accessed-pattern)'
       )
       .style('opacity', d => selected.includes(d.resource_name)
@@ -404,23 +404,6 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('width', mainWidth + mainMargin.left)
     .attr('height', mainHeight)
 
-  // Pattern for accessed: white dots on blue background
-  defs.append('pattern')
-    .attr('id', 'accessed-pattern')
-    .attr('width', 8)
-    .attr('height', 8)
-    .attr('patternUnits', 'userSpaceOnUse')
-    .append('rect')
-    .attr('width', 8)
-    .attr('height', 8)
-    .attr('fill', accessedResourceColor)
-  defs.select('#accessed-pattern')
-    .append('rect')
-    .attr('width', 2.5)
-    .attr('height', 2.5)
-    .attr('fill', 'white')
-    .attr('transform', 'translate(0,2)')
-
   // Pattern for not accessed: black stripes on gray background
   defs.append('pattern')
     .attr('id', 'not-accessed-pattern')
@@ -480,7 +463,7 @@ function createResourceAccessChart ({ data, width, height, domElement }) {
     .attr('height', miniYScale.bandwidth())
     .attr('class', 'bar')
     .attr('fill', d => d.self_access_count > 0
-      ? 'url(#accessed-pattern)'
+      ? accessedResourceColor
       : 'url(#not-accessed-pattern)'
     )
 


### PR DESCRIPTION
Added new visual indicators on resource access page to address accessibility concerns: https://github.com/tl-its-umich-edu/my-learning-analytics/issues/1250

- "Resources Accessed" bars retain the same secondary color from palette settings (blue)~~, with the addition of small white squares as a dotted pattern~~ EDIT: not necessary, as the solid pattern will be distinguishable with the stripes
- "Resources Not Accessed" bars retain the same negative color from the palette settings (gray), with the addition of diagonal black stripes
- Patterns are visually distinct with compliant contrast ratios according to WCAG 2.1 https://www.w3.org/TR/WCAG21/#non-text-contrast


