### PR TITLE
Bump mysqlclient from 2.2.0 to 2.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ pangres==4.2.1
 
 SQLAlchemy==2.0.23
 psycopg==3.1.12
-mysqlclient==2.2.0
+mysqlclient==2.2.4
 google-cloud-bigquery[pandas]==3.13.0
 
 debugpy==1.8.0


### PR DESCRIPTION
2.2.0 wasn't building for me on OSX with the latest MySQL client libraries. 2.2.4 builds fine.