### PR TITLE
changes to issue #1358 regarding .git extension

### DIFF
--- a/dashboard/common/utils.py
+++ b/dashboard/common/utils.py
@@ -13,9 +13,11 @@ logger = logging.getLogger(__name__)
 def format_github_url_using_https(github_url: str):
     ssh_base = "git@"
     https_base = "https://"
-    # If the URL is formatted for SSH, convert, otherwise, do nothing
+    # If the URL is formatted for SSH, convert, otherwise, replace .git extension with ""
     if ssh_base == github_url[:len(ssh_base)]:
         github_url = github_url.replace(":", "/").replace(".git", "").replace(ssh_base, https_base)
+    else:
+        github_url = github_url.replace(".git", "")
     return github_url
 
 


### PR DESCRIPTION
I added a statement to replace the .git extension at the end no matter what format it is and ensures that the ssh base still converts to https. This should remove any .git extension from any format of a url when cloning or adding a remote repo. Here is our test plan:

Our test plan is to test four different urls:

- The first test is to clone the repo with a https base url with the .git extension. The expected output is the same url but without the .git extension. This is to ensure that the https base gets the .git extension removed properly with our new code.
- input: https://github.com/tl-its-umich-edu/my-learning-analytics.git
- output: https://github.com/tl-its-umich-edu/my-learning-analytics

- The second test is to clone the repo with a ssh base url with the .git extension. The expected output will return the github url as https base and will have the .git extension removed. This is to ensure that the shh base functionality still works with the new code.
- input: git@github.com:tl-its-umich-edu/my-learning-analytics.git
- output: https://github.com/tl-its-umich-edu/my-learning-analytics

- The third test is to clone the repo with https base and no .git extension. The expected output will return the input string. This is to ensure that when an https base url is cloned without an extension, it still works properly and does not have any weird behavior.
- input: https://github.com/tl-its-umich-edu/my-learning-analytics
- output: https://github.com/tl-its-umich-edu/my-learning-analytics

- The final test is to clone the repo with ssh base and no .git extension. The expected output will return the github url as https base with no other modifications. This is to ensure that the code works properly with the new code and does not have any weird behavior. 
- input: git@github.com:tl-its-umich-edu/my-learning-analytics
- output: https://github.com/tl-its-umich-edu/my-learning-analytics