### PR TITLE
fixes #1592 Screen reader bug - Add Unique Ids to TextFields

### DIFF
--- a/assets/src/components/AssignmentGoalInput.js
+++ b/assets/src/components/AssignmentGoalInput.js
@@ -52,7 +52,7 @@ function AssignmentGoalInput (props) {
     <StyledGrid item>
       <StyledTextField
         error={goalGradeInternal > 100 || mathWarning || goalGradeInternal > maxPossibleGrade}
-        id='standard-number'
+        id='minimum-goal'
         value={goalGradeInternal}
         label={
           mathWarning

--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -448,7 +448,7 @@ function AssignmentTable (props) {
                               <StyledTextField
                                 error={(a.goalGrade / a.pointsPossible) > 1}
                                 disabled={!courseGoalGradeSet}
-                                id={`goal-grade-${key}}`}
+                                id={`goal-grade-${key}`}
                                 value={roundToXDecimals(a.goalGrade, placeToRoundTo(a.pointsPossible))}
                                 label={
                                   !courseGoalGradeSet

--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -448,7 +448,7 @@ function AssignmentTable (props) {
                               <StyledTextField
                                 error={(a.goalGrade / a.pointsPossible) > 1}
                                 disabled={!courseGoalGradeSet}
-                                id='standard-number'
+                                id={`goal-grade-${key}}`}
                                 value={roundToXDecimals(a.goalGrade, placeToRoundTo(a.pointsPossible))}
                                 label={
                                   !courseGoalGradeSet


### PR DESCRIPTION
Make unique IDs in Material UI to address the labels pointing to multiple input fields. 

Test plan: Use a screen reader to hover over all input fields ("My Minimum Goal" and multiple "Grade Goal" fields). Each input should have read aloud one singular label associated with it.