### PR TITLE
fixes #1594 add label names to assignment filter dropdowns

### DIFF
--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -309,7 +309,7 @@ function AssignmentTable (props) {
       <Grid container className={classes.filterArea}>
         <Grid item xs={12} sm={4}>
           <FormControl className={classes.formControl}>
-            <InputLabel>Filter by Type</InputLabel>
+            <InputLabel id='assignment-group-checkbox-label'>Filter by Type</InputLabel>
             <Select
               labelId='assignment-group-checkbox-label'
               id='assignment-group-mutiple-checkbox'
@@ -338,7 +338,7 @@ function AssignmentTable (props) {
         </Grid>
         <Grid item xs={12} sm={3}>
           <FormControl className={classes.formControl}>
-            <InputLabel>Filter by Status</InputLabel>
+            <InputLabel id='assignment-status-checkbox-label'>Filter by Status</InputLabel>
             <Select
               labelId='assignment-status-checkbox-label'
               id='assignment-status-mutiple-checkbox'


### PR DESCRIPTION
Use `id` prop on MaterialUI `InputLabel` component. Results in `aria-labelledBy` properly pointing to the component with the corresponding name:

<img width="589" alt="Screenshot 2024-08-30 at 11 52 23 AM" src="https://github.com/user-attachments/assets/08566f08-194b-4c80-abcc-6144807d73ba">
