### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -49,7 +49,7 @@ def lti_error(error_message: Any) -> JsonResponse:
     :return: JsonResponse, with status 500
     """
     logger.error(f'LTI error: {error_message}')
-    return JsonResponse({'lti_error': f'{error_message}'}, status=500)
+    return JsonResponse({'lti_error': 'An internal error has occurred.'}, status=500)
 
 
 class LTIException(Exception):


### PR DESCRIPTION
Fixes [https://github.com/tl-its-umich-edu/my-learning-analytics/security/code-scanning/1](https://github.com/tl-its-umich-edu/my-learning-analytics/security/code-scanning/1)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error messages on the server and return a generic error message to the user. This can be achieved by modifying the `lti_error` function to log the detailed error message and return a generic error message in the JSON response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
