### PR TITLE
#1626 fix watchman status messages

### DIFF
--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -175,6 +175,9 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
     },
+    'default': {
+        'BACKEND': 'django.core.files.storage.InMemoryStorage',
+    }
 }
 CONTEXT_PROCESSORS = [
     'django.contrib.auth.context_processors.auth',


### PR DESCRIPTION
Fixes #1626 

http://localhost:5001/status/ --> `{"databases": [{"default": {"ok": true}}], "caches": [{"default": {"ok": true}}], "storage": {"ok": true}}`
http://localhost:5001/status/bare_status --> just Returns a status 200 without any o/p response