### PR TITLE
added the lti launch time as the course last_access_date

### DIFF
--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -261,6 +261,8 @@ def extract_launch_variables_for_tool_use(request, message_launch):
 
     try:
         Course.objects.get(canvas_id=course_id)
+        # save the timestamp as the course last_accessed_date
+        Course.objects.filter(canvas_id=course_id).update(last_accessed_date=datetime.now())
     except ObjectDoesNotExist:
         if is_instructor or user_obj.is_staff:
             Course.objects.create(id=canvas_course_long_id, canvas_id=course_id, name=course_name)

--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -261,8 +261,6 @@ def extract_launch_variables_for_tool_use(request, message_launch):
 
     try:
         Course.objects.get(canvas_id=course_id)
-        # save the timestamp as the course last_accessed_date
-        Course.objects.filter(canvas_id=course_id).update(last_accessed_date=datetime.now())
     except ObjectDoesNotExist:
         if is_instructor or user_obj.is_staff:
             Course.objects.create(id=canvas_course_long_id, canvas_id=course_id, name=course_name)

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -2,7 +2,7 @@ import json
 import logging
 import math
 from collections import namedtuple
-from datetime import timedelta
+from datetime import timedelta, datetime
 from json import JSONDecodeError
 
 import jsonschema
@@ -102,6 +102,9 @@ def get_course_info(request, course_id=0):
 
     try:
         course = Course.objects.get(id=course_id)
+        # save the timestamp as the course last_accessed_date
+        course.last_accessed_date = datetime.now()
+        course.save()
     except ObjectDoesNotExist:
         return HttpResponse("{}")
 


### PR DESCRIPTION
Fixes #1624 

Test plan:

open the database and locate the last_access_date field of Course table 

The last_accessed_date can be updated via two routes:

Case 1: 
1. launch MyLA LTI on Canvas
2. notice the last_access_date timestamp is updated for this course

Case 2:
1. go to <myla_url>/courses/<course_id>
2. notice the last_access_date timestamp is updated for this course