### PR TITLE
#1631 instructor role can enable Myla

### DIFF
--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -184,7 +184,7 @@ def get_cache_config():
 # we don't want TA to enable the MyLA data extraction step.
 def check_if_instructor(roles, username, course_id):
     user_membership_roles = set([role for role in roles if role.find(COURSE_MEMBERSHIP) == 0])
-    if user_membership_roles and INSTRUCTOR in roles:
+    if user_membership_roles and INSTRUCTOR in user_membership_roles:
         logger.info(f'user {username} is Instructor in the course {course_id}')
         return True
     return False

--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -184,7 +184,7 @@ def get_cache_config():
 # we don't want TA to enable the MyLA data extraction step.
 def check_if_instructor(roles, username, course_id):
     user_membership_roles = set([role for role in roles if role.find(COURSE_MEMBERSHIP) == 0])
-    if user_membership_roles and INSTRUCTOR in roles and not TA in user_membership_roles:
+    if user_membership_roles and INSTRUCTOR in roles:
         logger.info(f'user {username} is Instructor in the course {course_id}')
         return True
     return False


### PR DESCRIPTION
Fixes #1631. Just checking is course membership has atleast `instructor` role then giving him the access
  "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",

With Only instructor role in a course will look like below
```
[
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
    "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
    "http://purl.imsglobal.org/vocab/lis/v2/system/person#User"
]
```

with instructor and TA role will look as below. This combination of role where membership is both instructor and TA are taken as instructor role and thus allow create a course in MyLA Database
```
[
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
    "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
    "http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant",
    "http://purl.imsglobal.org/vocab/lis/v2/system/person#User"
]
```
