### PR TITLE
issue_1642 make CANVAS_DATA_ID_INCREMENT as a required configration variable

### DIFF
--- a/config/env_sample.hjson
+++ b/config/env_sample.hjson
@@ -91,7 +91,7 @@
         "ROOT_PASSWORD": "student_dashboard_root_pw"
     },
     # Default Canvas Data id increment for course id, user id, etc
-    "CANVAS_DATA_ID_INCREMENT": 17700000000000000,
+    #"CANVAS_DATA_ID_INCREMENT": 17700000000000000,
     # Canvas Configuration
     "CANVAS_USER": "",
     # strings for construct file download url


### PR DESCRIPTION
- raise error when the CANVAS_DATA_ID_INCREMENT value is missing in config file, or not of integer type
- commented out the CANVAS_DATA_ID_INCREMENT setting line in the env_sample.hjson file