### PR TITLE
#1631 any user with teacher role can enable courses

### DIFF
--- a/assets/config/lti_config_template.json
+++ b/assets/config/lti_config_template.json
@@ -37,6 +37,7 @@
   "public_jwk": {},
   "description": "MyLA automatically generated configuration",
   "custom_fields": {
+    "canvas_course_roles": "$Canvas.membership.roles",
     "user_username": "$User.username",
     "canvas_user_id": "$Canvas.user.id",
     "canvas_course_id": "$Canvas.course.id",

--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -31,6 +31,7 @@ INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor'
 TA = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant'
 COURSE_MEMBERSHIP = 'http://purl.imsglobal.org/vocab/lis/v2/membership'
 DUMMY_CACHE = 'DummyCache'
+CANVAS_TEACHER_ROLE = 'TeacherEnrollment'
 
 # do not require deployment ids if LTI_CONFIG_DISABLE_DEPLOYMENT_ID_VALIDATION is true
 class ExtendedDjangoMessageLaunch(DjangoMessageLaunch):
@@ -184,7 +185,7 @@ def get_cache_config():
 # we don't want TA to enable the MyLA data extraction step.
 def check_if_instructor(roles, canvas_course_roles, username, course_id):
     user_membership_roles = set([role for role in roles if role.find(COURSE_MEMBERSHIP) == 0])
-    if user_membership_roles and 'teacher' in canvas_course_roles.lower():
+    if user_membership_roles and CANVAS_TEACHER_ROLE in [role.strip() for role in canvas_course_roles.split(",")]:
         logger.info(f'user {username} is Instructor in the course {course_id}')
         return True
     return False

--- a/dashboard/lti_new.py
+++ b/dashboard/lti_new.py
@@ -182,9 +182,9 @@ def get_cache_config():
 # Checking if user only has Instructor role in a course to enable MyLA in courses.
 # A TA could be an instructor in an course section so his role will be both TA and Instructor.
 # we don't want TA to enable the MyLA data extraction step.
-def check_if_instructor(roles, username, course_id):
+def check_if_instructor(roles, canvas_course_roles, username, course_id):
     user_membership_roles = set([role for role in roles if role.find(COURSE_MEMBERSHIP) == 0])
-    if user_membership_roles and INSTRUCTOR in user_membership_roles:
+    if user_membership_roles and 'teacher' in canvas_course_roles.lower():
         logger.info(f'user {username} is Instructor in the course {course_id}')
         return True
     return False
@@ -224,6 +224,7 @@ def extract_launch_variables_for_tool_use(request, message_launch):
     username = custom_params['user_username']
     course_id = custom_params['canvas_course_id']
     canvas_user_id = custom_params['canvas_user_id']
+    canvas_course_roles = custom_params.get('canvas_course_roles', '')
     time_zone = custom_params.get('person_address_timezone',
                                   settings.TIME_ZONE).strip()
 
@@ -257,7 +258,7 @@ def extract_launch_variables_for_tool_use(request, message_launch):
 
     user_obj.backend = 'django.contrib.auth.backends.ModelBackend'
     django.contrib.auth.login(request, user_obj)
-    is_instructor = check_if_instructor(roles, username, course_id)
+    is_instructor = check_if_instructor(roles, canvas_course_roles, username, course_id)
 
     try:
         Course.objects.get(canvas_id=course_id)


### PR DESCRIPTION
Fixes #1631 

TA role is set with below 2 string with course membership. So there is no differentiator if user is TA or Teacher in course via LTI role mapping
```
 "https://purl.imsglobal.org/spec/lti/claim/roles": [
"http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
    "http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant",
]
```

So we are adding new LTI custom variable to Myla called   ` "canvas_course_roles": "$Canvas.membership.roles"` for exact user role in a course: https://developerdocs.instructure.com/services/canvas/external-tools/lti/file.tools_variable_substitutions#canvas.membership.roles

While Custom LTI role check might be sufficient, but I am still checking in LTI role list for course membership ( existing check) and adding on new check with custom LTI param for determining TA Only or not


Course: 730941, has good mix of Teacher only, TA only and Teacher & TA as well.  

Testing:
1. Make sure MYLA LTI with new custom role `canvas_course_roles`
2. Do the LTI launch with various course role
   3. Teacher Only --> create course in Myla
   4. TA and Teacher --> create course in Myla
   5. TA only --> **can't create course Myla**