### PR TITLE
django-filter 25.2 depends on Django>=5.2.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Update this manually when updating Django/Python to supported version
+      - dependency-name: "django-filter"
+        versions: ["*"]
     groups:
       all-python-dependencies:
         patterns: ["*"]


### PR DESCRIPTION
Added a comment to indicate manual update needed for Django/Python version.

Same fix in https://github.com/tl-its-umich-edu/instructor-tools/pull/498