### PR TITLE
upgrade OS from bookworm to trixie (iss. #1752)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Version for MariaDB database package. LTS version is currently being preferred
 ARG MARIADB_VERSION=11.8
 # Named version of Debian to use
-ARG DEBIAN_VERSION=bookworm
+ARG DEBIAN_VERSION=trixie
 # Version of Node.js
 ARG NODE_VERSION=20
 # Version of Python


### PR DESCRIPTION
Resolves #1752.

The bookworm version of Linux will be unsupported soon.  Upgrade to trixie now to ensure MyLA continues to operate correctly, with plenty of time to troubleshoot if there are issues following the upgrade.