### PR TITLE
Fixes #1759 Downgrade graphql-core for broken Assignment Planning page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ fontawesomefree==6.6.0
 
 # graphql
 graphene-django==3.2.3
+graphql-core==3.2.9
 graphql-core-promise==3.4.2
 django-filter==25.1
 


### PR DESCRIPTION
lock graphql-core from latest (3.2.11). 

As of now, version 3.2.9 is the only api compatible with [graphql-core-promise](https://github.com/fellowapp/graphql-core-promise). See issue #1759 and [slack discussion](https://umich-its-annarbor.slack.com/archives/GNSJ3RMHN/p1783454279041919)

Test plan:
- load Assignment Planning page 
- test some write operations (change expected grade, lock grades)