### PR TITLE
Fixes #1750 Add database .pem SSL file to DB config

### DIFF
--- a/config/env_sample.hjson
+++ b/config/env_sample.hjson
@@ -72,7 +72,13 @@
         # Local database port
         "PORT": 3306,
         # Local database root password (optional)
-        "ROOT_PASSWORD": "student_dashboard_root_pw"
+        "ROOT_PASSWORD": "student_dashboard_root_pw",
+        "OPTIONS": {
+            "charset": "utf8mb4",
+            # Option to enforce SSL connection to MySQL DB
+            #"ssl": { "ca": "/secrets/ssl-ca-filename.pem" },
+            #"ssl_mode": "REQUIRED",
+        },
     },
     # Default Canvas Data id increment for course id, user id, etc
     #"CANVAS_DATA_ID_INCREMENT": 17700000000000000,


### PR DESCRIPTION
Fixes #1750

Test plan: 
- change MYSQL connection credentials in env.hjson to test or dev DB
- add .pem file to your local mylasecrets folder, add "OPTIONS" with the correct ssl filename configured (And ssl_mode: required)
- run local app, check db connection is successful 

optionally, run shell commands to verify, eg:
```
from django.db import connection
connection.ensure_connection()
with connection.cursor() as cursor:
    cursor.execute('SHOW SESSION STATUS LIKE \"Ssl_cipher\"')
    cipher = cursor.fetchone()
    cursor.execute('SHOW SESSION STATUS LIKE \"Ssl_version\"')
    version = cursor.fetchone()
    print('SSL Cipher:', cipher[1] if cipher else 'Not using SSL')
    print('SSL Version:', version[1] if version else 'Not using SSL')
```